### PR TITLE
Fixing wgpu feature hardcoded to ‘vulkan’.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ dx12 = ["wgpu/dx12"]
 vulkan = ["wgpu/vulkan"]
 
 [dependencies]
-wgpu = { version = "0.3.0", features = ["vulkan"] }
+wgpu = { version = "0.3.0" }
 cgmath = "0.17"
 env_logger = "0.5"
 glsl-to-spirv = "0.1"


### PR DESCRIPTION
Fixes Metal build on Mac OS X. I think the feature is derived in webgpu automatically, please double check it works on Vulkan.