### PR TITLE
change render() parameters

### DIFF
--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -167,7 +167,7 @@ fn main() {
 
                 platform.prepare_render(&ui, &window);
                 renderer
-                    .render(ui, &mut device, &mut encoder, &frame.view)
+                    .render(ui.render(), &mut device, &mut encoder, &frame.view)
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -176,7 +176,7 @@ fn main() {
 
                 platform.prepare_render(&ui, &window);
                 renderer
-                    .render(ui, &mut device, &mut encoder, &frame.view)
+                    .render(ui.render(), &mut device, &mut encoder, &frame.view)
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::mem::size_of;
 use imgui::{
     DrawList,
     Context,
+    DrawData,
     DrawVert,
     DrawIdx,
     TextureId,
@@ -293,14 +294,13 @@ impl Renderer {
     }
 
     /// Render the current imgui frame.
-    pub fn render<'a>(
+    pub fn render(
         &mut self,
-        ui: Ui<'a>,
+        draw_data: &DrawData,
         device: &Device,
         encoder: &mut CommandEncoder,
         view: &TextureView,
     ) -> RendererResult<()> {
-        let draw_data = ui.render();
         let fb_width = draw_data.display_size[0] * draw_data.framebuffer_scale[0];
         let fb_height = draw_data.display_size[1] * draw_data.framebuffer_scale[1];
         


### PR DESCRIPTION
I just changed the `Ui` parameter to a `&DrawData` one.
This difference make possible the reuse of `DrawData` in your app, which can be very useful when rendering and event_handling are asynchronous.
That was impossible before, because the `ui` was consumed inside the render function with `ui.render()`, which forced the user to recreate `ui` each time it was drawn.