### PR TITLE
fix examples to use new winit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,11 +304,6 @@ dependencies = [
 
 [[package]]
 name = "dispatch"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -571,17 +566,6 @@ dependencies = [
 
 [[package]]
 name = "imgui"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "imgui-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "imgui"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -589,14 +573,6 @@ dependencies = [
  "imgui-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "imgui-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cc 1.0.50 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -615,7 +591,7 @@ dependencies = [
  "glsl-to-spirv 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "imgui 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui-winit-support 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "wgpu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -624,11 +600,11 @@ dependencies = [
 
 [[package]]
 name = "imgui-winit-support"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "winit 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "imgui 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winit 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1594,34 +1570,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "winit"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cocoa 0.19.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-graphics 0.17.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "core-video-sys 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "dispatch 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "instant 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.21 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio-extras 2.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "objc 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "parking_lot 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "raw-window-handle 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "smithay-client-toolkit 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "wayland-client 0.23.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "x11-dl 2.18.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "winit"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1755,7 +1703,6 @@ dependencies = [
 "checksum d3d12 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc7ed48e89905e5e146bcc1951cc3facb9e44aea9adf5dc01078cda1bd24b662"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
-"checksum dispatch 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e93ca78226c51902d7aa8c12c988338aadd9e85ed9c6be8aaac39192ff3605"
 "checksum dispatch 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 "checksum dlib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "77e51249a9d823a4cb79e3eca6dcd756153e8ed0157b6c04775d04bf1b13b76a"
 "checksum downcast-rs 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "52ba6eb47c2131e784a38b726eb54c1e1484904f013e576a25354d0124161af6"
@@ -1782,11 +1729,9 @@ dependencies = [
 "checksum hibitset 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "93a1bb8316a44459a7d14253c4d28dd7395cbd23cc04a68c46e851b8e46d64b1"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum image 0.22.5 (registry+https://github.com/rust-lang/crates.io-index)" = "08ed2ada878397b045454ac7cfb011d73132c59f31a955d230bd1f1c2e68eb4a"
-"checksum imgui 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e70a1b421ac503e94009cc9bcd6ed256f6bf38ced98d841b095da6b94ea67702"
 "checksum imgui 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a2d28cee2982d4dab4dd954c23be339ab1f98be4ff5a13ecd8fbfb47cdfa23a"
-"checksum imgui-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0350b22f0a64eeb852ed3995ddb5d6d24bd3038024d2bd81720a6573baa602dc"
 "checksum imgui-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "21a8693e0f66ecd2ec10e2f0ed4dc4519071495f350e6d8ddaf3e70351229257"
-"checksum imgui-winit-support 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6c63c45c058634dbc045dde485a7baf0f4321b77c00cca90c5d2d9b3ab2f5eec"
+"checksum imgui-winit-support 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a90f2e2a24b82dbd7aa9eb20825cd6421af5d40643d329d8e7bb1ae37a962ffe"
 "checksum inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1cdb29978cc5797bd8dcc8e5bf7de604891df2a8dc576973d71a281e916db2ff"
 "checksum instant 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6c346c299e3fe8ef94dc10c2c0253d858a69aac1245157a3bf4125915d528caf"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
@@ -1898,7 +1843,6 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4ccfbf554c6ad11084fb7517daca16cfdcaccbdadba4fc336f032a8b12c2ad80"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-"checksum winit 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ba128780050481f453bec2a115b916dbc6ae79c303dee9bad8b9080bdccd4f5"
 "checksum winit 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)" = "65a5c1a5ef76ac31cc97ad29489acdbed2178f3fc12ca00ee6cb11d60adb5a3a"
 "checksum wio 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5d129932f4644ac2396cb456385cbf9e63b5b30c6e8dc4820bdca4eb082037a5"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ env_logger = "0.5"
 image = "0.22"
 
 [dev-dependencies.imgui-winit-support]
-version = "0.2.0"
+version = "0.3"
 default-features = false
 features = ["winit-20"]

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -1,49 +1,42 @@
-use winit::{
-    event::{
-        Event,
-        WindowEvent,
-        KeyboardInput,
-        VirtualKeyCode,
-        ElementState,
-    },
-    event_loop::{
-        EventLoop,
-        ControlFlow,
-    },
-    dpi::LogicalSize,
-    window::Window,
-};
+use image::ImageFormat;
 use imgui::*;
 use imgui_wgpu::Renderer;
 use imgui_winit_support;
 use std::time::Instant;
-use image::ImageFormat;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
 
 fn main() {
     env_logger::init();
 
-    // Set up window and GPU    
+    // Set up window and GPU
     let event_loop = EventLoop::new();
-    let (window, mut size, surface, hidpi_factor) = {
+    let mut hidpi_factor = 1.0;
+    let (window, mut size, surface) = {
         let version = env!("CARGO_PKG_VERSION");
 
         let window = Window::new(&event_loop).unwrap();
-        window.set_inner_size(LogicalSize { width: 1280.0, height: 720.0 });
+        window.set_inner_size(LogicalSize {
+            width: 1280.0,
+            height: 720.0,
+        });
         window.set_title(&format!("imgui-wgpu {}", version));
-        let hidpi_factor = window.hidpi_factor();
-        let size = window
-            .inner_size()
-            .to_physical(hidpi_factor);
+        let size = window.inner_size();
 
         let surface = wgpu::Surface::create(&window);
 
-        (window, size, surface, hidpi_factor)
+        (window, size, surface)
     };
 
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::LowPower,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     let (mut device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
@@ -66,34 +59,48 @@ fn main() {
     // Set up dear imgui
     let mut imgui = imgui::Context::create();
     let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
-    platform.attach_window(imgui.io_mut(), &window, imgui_winit_support::HiDpiMode::Default);
+    platform.attach_window(
+        imgui.io_mut(),
+        &window,
+        imgui_winit_support::HiDpiMode::Default,
+    );
     imgui.set_ini_filename(None);
 
     let font_size = (13.0 * hidpi_factor) as f32;
     imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
 
-    imgui.fonts().add_font(&[
-        FontSource::DefaultFontData {
-            config: Some(imgui::FontConfig {
-                oversample_h: 1,
-                pixel_snap_h: true,
-                size_pixels: font_size,
-                ..Default::default()
-            })
-        }
-    ]);
+    imgui.fonts().add_font(&[FontSource::DefaultFontData {
+        config: Some(imgui::FontConfig {
+            oversample_h: 1,
+            pixel_snap_h: true,
+            size_pixels: font_size,
+            ..Default::default()
+        }),
+    }]);
 
     //
     // Set up dear imgui wgpu renderer
-    // 
-    let clear_color = wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 };
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, Some(clear_color));
+    //
+    let clear_color = wgpu::Color {
+        r: 0.1,
+        g: 0.2,
+        b: 0.3,
+        a: 1.0,
+    };
+    let mut renderer = Renderer::new(
+        &mut imgui,
+        &device,
+        &mut queue,
+        sc_desc.format,
+        Some(clear_color),
+    );
 
     let mut last_frame = Instant::now();
-    
+
     // Set up Lenna texture
     let lenna_bytes = include_bytes!("../resources/Lenna.jpg");
-    let image = image::load_from_memory_with_format(lenna_bytes, ImageFormat::JPEG).expect("inavlid image");
+    let image =
+        image::load_from_memory_with_format(lenna_bytes, ImageFormat::JPEG).expect("inavlid image");
     let image = image.to_rgba();
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
@@ -108,46 +115,53 @@ fn main() {
         };
         match event {
             Event::WindowEvent {
+                event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
+                ..
+            } => {
+                hidpi_factor = scale_factor;
+            }
+            Event::WindowEvent {
                 event: WindowEvent::Resized(_),
                 ..
             } => {
-                size = window
-                    .inner_size()
-                    .to_physical(hidpi_factor);
+                size = window.inner_size();
 
                 sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8Unorm,
                     width: size.width as u32,
                     height: size.height as u32,
-                    present_mode: wgpu::PresentMode::NoVsync
+                    present_mode: wgpu::PresentMode::NoVsync,
                 };
 
                 swap_chain = device.create_swap_chain(&surface, &sc_desc);
             }
             Event::WindowEvent {
-                event: WindowEvent::KeyboardInput {
-                    input: KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::Escape),
-                        state: ElementState::Pressed,
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                                state: ElementState::Pressed,
+                                ..
+                            },
                         ..
                     },
-                    ..
-                },
                 ..
-            } |
-            Event::WindowEvent {
+            }
+            | Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
                 *control_flow = ControlFlow::Exit;
-            },
-            Event::EventsCleared => {
+            }
+            Event::MainEventsCleared => {
                 let now = Instant::now();
                 last_frame = now;
 
                 let frame = swap_chain.get_next_texture();
-                platform.prepare_frame(imgui.io_mut(), &window)
+                platform
+                    .prepare_frame(imgui.io_mut(), &window)
                     .expect("Failed to prepare frame");
                 let ui = imgui.frame();
 
@@ -163,7 +177,8 @@ fn main() {
                         });
                 }
 
-                let mut encoder: wgpu::CommandEncoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+                let mut encoder: wgpu::CommandEncoder =
+                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
 
                 platform.prepare_render(&ui, &window);
                 renderer
@@ -171,7 +186,7 @@ fn main() {
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);
-            },
+            }
             _ => (),
         }
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,48 +1,41 @@
-use winit::{
-    event::{
-        Event,
-        WindowEvent,
-        KeyboardInput,
-        VirtualKeyCode,
-        ElementState,
-    },
-    event_loop::{
-        EventLoop,
-        ControlFlow,
-    },
-    dpi::LogicalSize,
-    window::Window,
-};
 use imgui::*;
 use imgui_wgpu::Renderer;
 use imgui_winit_support;
 use std::time::Instant;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
 
 fn main() {
     env_logger::init();
 
-    // Set up window and GPU    
+    // Set up window and GPU
     let event_loop = EventLoop::new();
-    let (window, mut size, surface, hidpi_factor) = {
+    let mut hidpi_factor = 1.0;
+    let (window, mut size, surface) = {
         let version = env!("CARGO_PKG_VERSION");
 
         let window = Window::new(&event_loop).unwrap();
-        window.set_inner_size(LogicalSize { width: 1280.0, height: 720.0 });
+        window.set_inner_size(LogicalSize {
+            width: 1280.0,
+            height: 720.0,
+        });
         window.set_title(&format!("imgui-wgpu {}", version));
-        let hidpi_factor = window.hidpi_factor();
-        let size = window
-            .inner_size()
-            .to_physical(hidpi_factor);
+        let size = window.inner_size();
 
         let surface = wgpu::Surface::create(&window);
 
-        (window, size, surface, hidpi_factor)
+        (window, size, surface)
     };
 
     let adapter = wgpu::Adapter::request(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::LowPower,
         backends: wgpu::BackendBit::PRIMARY,
-    }).unwrap();
+    })
+    .unwrap();
 
     let (mut device, mut queue) = adapter.request_device(&wgpu::DeviceDescriptor {
         extensions: wgpu::Extensions {
@@ -65,28 +58,41 @@ fn main() {
     // Set up dear imgui
     let mut imgui = imgui::Context::create();
     let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
-    platform.attach_window(imgui.io_mut(), &window, imgui_winit_support::HiDpiMode::Default);
+    platform.attach_window(
+        imgui.io_mut(),
+        &window,
+        imgui_winit_support::HiDpiMode::Default,
+    );
     imgui.set_ini_filename(None);
 
     let font_size = (13.0 * hidpi_factor) as f32;
     imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
 
-    imgui.fonts().add_font(&[
-        FontSource::DefaultFontData {
-            config: Some(imgui::FontConfig {
-                oversample_h: 1,
-                pixel_snap_h: true,
-                size_pixels: font_size,
-                ..Default::default()
-            })
-        }
-    ]);
+    imgui.fonts().add_font(&[FontSource::DefaultFontData {
+        config: Some(imgui::FontConfig {
+            oversample_h: 1,
+            pixel_snap_h: true,
+            size_pixels: font_size,
+            ..Default::default()
+        }),
+    }]);
 
     //
     // Set up dear imgui wgpu renderer
-    // 
-    let clear_color = wgpu::Color { r: 0.1, g: 0.2, b: 0.3, a: 1.0 };
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, Some(clear_color));
+    //
+    let clear_color = wgpu::Color {
+        r: 0.1,
+        g: 0.2,
+        b: 0.3,
+        a: 1.0,
+    };
+    let mut renderer = Renderer::new(
+        &mut imgui,
+        &device,
+        &mut queue,
+        sc_desc.format,
+        Some(clear_color),
+    );
 
     let mut last_frame = Instant::now();
     let mut demo_open = true;
@@ -100,48 +106,55 @@ fn main() {
         };
         match event {
             Event::WindowEvent {
+                event: WindowEvent::ScaleFactorChanged { scale_factor, .. },
+                ..
+            } => {
+                hidpi_factor = scale_factor;
+            }
+            Event::WindowEvent {
                 event: WindowEvent::Resized(_),
                 ..
             } => {
-                size = window
-                    .inner_size()
-                    .to_physical(hidpi_factor);
+                size = window.inner_size();
 
                 sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8Unorm,
                     width: size.width as u32,
                     height: size.height as u32,
-                    present_mode: wgpu::PresentMode::NoVsync
+                    present_mode: wgpu::PresentMode::NoVsync,
                 };
 
                 swap_chain = device.create_swap_chain(&surface, &sc_desc);
             }
             Event::WindowEvent {
-                event: WindowEvent::KeyboardInput {
-                    input: KeyboardInput {
-                        virtual_keycode: Some(VirtualKeyCode::Escape),
-                        state: ElementState::Pressed,
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                                state: ElementState::Pressed,
+                                ..
+                            },
                         ..
                     },
-                    ..
-                },
                 ..
-            } |
-            Event::WindowEvent {
+            }
+            | Event::WindowEvent {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
                 *control_flow = ControlFlow::Exit;
-            },
-            Event::EventsCleared => {
+            }
+            Event::MainEventsCleared => {
                 let now = Instant::now();
                 let delta = now - last_frame;
                 let delta_s = delta.as_micros();
                 last_frame = now;
 
                 let frame = swap_chain.get_next_texture();
-                platform.prepare_frame(imgui.io_mut(), &window)
+                platform
+                    .prepare_frame(imgui.io_mut(), &window)
                     .expect("Failed to prepare frame");
                 let ui = imgui.frame();
 
@@ -172,7 +185,8 @@ fn main() {
                     ui.show_demo_window(&mut demo_open);
                 }
 
-                let mut encoder: wgpu::CommandEncoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
+                let mut encoder: wgpu::CommandEncoder =
+                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor { todo: 0 });
 
                 platform.prepare_render(&ui, &window);
                 renderer
@@ -180,7 +194,7 @@ fn main() {
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);
-            },
+            }
             _ => (),
         }
 


### PR DESCRIPTION
i'm sorry, forgot update winit in examples; i tested with another project it works fine :)

i also accidentally rust formated examples (format on save); i can undo if want but can i just leave it?