### PR TITLE
Replace &mut Queue with &Queue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ impl Renderer {
     pub fn new_glsl(
         imgui: &mut Context,
         device: &Device,
-        queue: &mut Queue,
+        queue: &Queue,
         format: TextureFormat,
         clear_color: Option<Color>,
     ) -> Renderer {
@@ -118,7 +118,7 @@ impl Renderer {
     pub fn new(
         imgui: &mut Context,
         device: &Device,
-        queue: &mut Queue,
+        queue: &Queue,
         format: TextureFormat,
         clear_color: Option<Color>,
     ) -> Renderer {
@@ -150,7 +150,7 @@ impl Renderer {
     pub fn new_static(
         imgui: &mut Context,
         device: &Device,
-        queue: &mut Queue,
+        queue: &Queue,
         format: TextureFormat,
         clear_color: Option<Color>,
     ) -> Renderer {
@@ -161,7 +161,7 @@ impl Renderer {
     fn new_impl(
         imgui: &mut Context,
         device: &Device,
-        queue: &mut Queue,
+        queue: &Queue,
         format: TextureFormat,
         clear_color: Option<Color>,
         vs_raw: Vec<u32>,
@@ -475,7 +475,7 @@ impl Renderer {
     /// Updates the texture on the GPU corresponding to the current imgui font atlas.
     ///
     /// This has to be called after loading a font.
-    pub fn reload_font_texture(&mut self, imgui: &mut Context, device: &Device, queue: &mut Queue) {
+    pub fn reload_font_texture(&mut self, imgui: &mut Context, device: &Device, queue: &Queue) {
         let mut atlas = imgui.fonts();
         let handle = atlas.build_rgba32_texture();
         let font_texture_id =
@@ -488,7 +488,7 @@ impl Renderer {
     pub fn upload_texture(
         &mut self,
         device: &Device,
-        queue: &mut Queue,
+        queue: &Queue,
         data: &[u8],
         width: u32,
         height: u32,


### PR DESCRIPTION
Prevents borrow errors with another library I'm using, and Queue has no `&mut self` methods. Please make a new release after merging this :).