### PR TITLE
Update WGPU to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,15 +16,17 @@ license = "MIT OR Apache-2.0"
 default = []
 
 [dependencies]
-wgpu = "0.5"
+wgpu = "0.6"
 glsl-to-spirv = { version = "0.1", optional = true }
 log = "0.4"
 imgui = "0.4"
+bytemuck = "1"
+smallvec = "1"
 
 [dev-dependencies]
+wgpu-subscriber = "0.1"
 winit = "0.22"
 raw-window-handle = "0.3"
-env_logger = "0.7"
 image = "0.23"
 futures = "0.3"
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ cargo run --release --example hello_world
 
 # Status
 
-Basic features are useable. Uses `wgpu-0.5.0` and `imgui-0.3.0` upstream. `winit-0.21` is used with the examples.
+Basic features are useable. Uses `wgpu-0.6.0` and `imgui-0.4.0` upstream. `winit-0.22` is used with the examples.
 
 Contributions are very welcome.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -11,11 +11,14 @@ use winit::{
 };
 
 fn main() {
-    env_logger::init();
+    wgpu_subscriber::initialize_default_subscriber(None);
 
     // Set up window and GPU
     let event_loop = EventLoop::new();
     let mut hidpi_factor = 1.0;
+
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+
     let (window, mut size, surface) = {
         let version = env!("CARGO_PKG_VERSION");
 
@@ -27,26 +30,26 @@ fn main() {
         window.set_title(&format!("imgui-wgpu {}", version));
         let size = window.inner_size();
 
-        let surface = wgpu::Surface::create(&window);
+        let surface = unsafe { instance.create_surface(&window) };
 
         (window, size, surface)
     };
 
-    let adapter = block_on(wgpu::Adapter::request(
-        &wgpu::RequestAdapterOptions {
-            power_preference: wgpu::PowerPreference::HighPerformance,
-            compatible_surface: Some(&surface),
-        },
-        wgpu::BackendBit::PRIMARY,
-    ))
+    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: Some(&surface),
+    }))
     .unwrap();
 
-    let (mut device, mut queue) = block_on(adapter.request_device(&wgpu::DeviceDescriptor {
-        extensions: wgpu::Extensions {
-            anisotropic_filtering: false,
+    let (device, mut queue) = block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            features: wgpu::Features::empty(),
+            limits: wgpu::Limits::default(),
+            shader_validation: false,
         },
-        limits: wgpu::Limits::default(),
-    }));
+        None,
+    ))
+    .unwrap();
 
     // Set up swap chain
     let mut sc_desc = wgpu::SwapChainDescriptor {
@@ -92,22 +95,10 @@ fn main() {
     };
 
     #[cfg(not(feature = "glsl-to-spirv"))]
-    let mut renderer = Renderer::new(
-        &mut imgui,
-        &device,
-        &mut queue,
-        sc_desc.format,
-        Some(clear_color),
-    );
+    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format);
 
     #[cfg(feature = "glsl-to-spirv")]
-    let mut renderer = Renderer::new_glsl(
-        &mut imgui,
-        &device,
-        &mut queue,
-        sc_desc.format,
-        Some(clear_color),
-    );
+    let mut renderer = Renderer::new_glsl(&mut imgui, &device, &mut queue, sc_desc.format);
 
     let mut last_frame = Instant::now();
     let mut demo_open = true;
@@ -168,7 +159,7 @@ fn main() {
                 let delta_s = last_frame.elapsed();
                 last_frame = imgui.io_mut().update_delta_time(last_frame);
 
-                let frame = match swap_chain.get_next_texture() {
+                let frame = match swap_chain.get_current_frame() {
                     Ok(frame) => frame,
                     Err(e) => {
                         eprintln!("dropped frame: {:?}", e);
@@ -214,11 +205,26 @@ fn main() {
                     last_cursor = Some(ui.mouse_cursor());
                     platform.prepare_render(&ui, &window);
                 }
+
+                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: &frame.output.view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(clear_color),
+                            store: true,
+                        },
+                    }],
+                    depth_stencil_attachment: None,
+                });
+
                 renderer
-                    .render(ui.render(), &mut device, &mut encoder, &frame.view)
+                    .render(ui.render(), &queue, &device, &mut rpass)
                     .expect("Rendering failed");
 
-                queue.submit(&[encoder.finish()]);
+                drop(rpass);
+
+                queue.submit(Some(encoder.finish()));
             }
             _ => (),
         }


### PR DESCRIPTION
wgpu 0.6 just dropped earlier today, and I know how many people use this library, so I wanted to help out and update this to 0.6!

Besides upgrading to 0.6 I changed a couple performance and QOL related things that have been discovered in the 0.5 -> 0.6 transition.
- Added labels for all things which take labels.
- Remove staging buffers as `queue.write_buffer`/`device.create_buffer_init` now efficiently implement staging buffers automatically.
- Use bytemuck for conversions between types and a pile of bytes. (very small dependency which most users will already depend on)
- Use smallvecs to store vertex/index buffers to save some allocations and keep things on the stack. (wgpu already depends on smallvec, so this is "free")
- Change the api so that users provide their own renderpass. This allows the user to combine imgui-wgpu's renderpass with theirs, reducing the renderpass count. On all mobile chips (and new ARM macs) which are tile-based, keeping renderpass count low is very important for performance.
- Use wgpu_subscriber to provide logging in the examples as is required in 0.6.

If you have any questions/comments/issues please let me know, we can also have a more casual chat on the wgpu matrix if you'd wish. Thanks for the work on this library!