### PR TITLE
Added MSAA support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,20 +16,20 @@ license = "MIT OR Apache-2.0"
 default = []
 
 [dependencies]
-wgpu = "0.5"
-glsl-to-spirv = { version = "0.1", optional = true }
-log = "0.4"
-imgui = "0.4"
+wgpu = "~0.5.2"
+glsl-to-spirv = { version = "~0.1.7", optional = true }
+log = "~0.4.11"
+imgui = "~0.4.0"
 
 [dev-dependencies]
-winit = "0.22"
-raw-window-handle = "0.3"
-env_logger = "0.7"
-image = "0.23"
-futures = "0.3"
+winit = "0.22.2"
+raw-window-handle = "0.3.3"
+env_logger = "0.7.1"
+image = "0.23.8"
+futures = "0.3.5"
 
 [dev-dependencies.imgui-winit-support]
-version = "0.4"
+version = "0.4.0"
 default-features = false
 features = ["winit-22"]
 

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -95,8 +95,9 @@ fn main() {
         &mut imgui,
         &device,
         &mut queue,
-        sc_desc.format,
+        &sc_desc,
         Some(clear_color),
+        1
     );
 
     let mut last_frame = Instant::now();
@@ -199,7 +200,7 @@ fn main() {
                     platform.prepare_render(&ui, &window);
                 }
                 renderer
-                    .render(ui.render(), &mut device, &mut encoder, &frame.view)
+                    .render(ui.render(), &mut device, &mut encoder, &frame.view, &sc_desc)
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -96,8 +96,9 @@ fn main() {
         &mut imgui,
         &device,
         &mut queue,
-        sc_desc.format,
+        &sc_desc,
         Some(clear_color),
+        1
     );
 
     #[cfg(feature = "glsl-to-spirv")]
@@ -105,8 +106,9 @@ fn main() {
         &mut imgui,
         &device,
         &mut queue,
-        sc_desc.format,
+        &sc_desc,
         Some(clear_color),
+        1
     );
 
     let mut last_frame = Instant::now();
@@ -215,7 +217,7 @@ fn main() {
                     platform.prepare_render(&ui, &window);
                 }
                 renderer
-                    .render(ui.render(), &mut device, &mut encoder, &frame.view)
+                    .render(ui.render(), &mut device, &mut encoder, &frame.view, &sc_desc)
                     .expect("Rendering failed");
 
                 queue.submit(&[encoder.finish()]);


### PR DESCRIPTION
I've added optional MSAA (multisample anti-aliasing) support. The MSAA framebuffer is automatically recreated in the `render()` method if its size doesn't match with that of the `SwapChainDescriptor`.

Additionally, I've updated the dependency versions and made them [Tilde requirements](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#tilde-requirements).

I'm also not sure if a possible shared font atlas is handled correctly.