### PR TITLE
Better texture support

### DIFF
--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -95,7 +95,7 @@ fn main() {
         b: 0.3,
         a: 1.0,
     };
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format);
+    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
 
     let mut last_frame = Instant::now();
 

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -1,7 +1,7 @@
 use futures::executor::block_on;
 use image::ImageFormat;
 use imgui::*;
-use imgui_wgpu::{Renderer, Texture, TextureConfig};
+use imgui_wgpu::{RendererConfig, TextureConfig};
 use imgui_winit_support;
 use std::time::Instant;
 use winit::{
@@ -43,7 +43,7 @@ fn main() {
     }))
     .unwrap();
 
-    let (device, mut queue) = block_on(adapter.request_device(
+    let (device, queue) = block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
             features: wgpu::Features::empty(),
             limits: wgpu::Limits::default(),
@@ -95,7 +95,9 @@ fn main() {
         b: 0.3,
         a: 1.0,
     };
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
+    let mut renderer = RendererConfig::new()
+        .set_texture_format(sc_desc.format)
+        .build(&mut imgui, &device, &queue);
 
     let mut last_frame = Instant::now();
 
@@ -103,7 +105,7 @@ fn main() {
     let lenna_bytes = include_bytes!("../resources/Lenna.jpg");
     let image =
         image::load_from_memory_with_format(lenna_bytes, ImageFormat::Jpeg).expect("invalid image");
-    let image = image.to_rgba();
+    let image = image.to_bgra();
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
 

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -1,7 +1,7 @@
 use futures::executor::block_on;
 use image::ImageFormat;
 use imgui::*;
-use imgui_wgpu::Renderer;
+use imgui_wgpu::{Renderer, Texture};
 use imgui_winit_support;
 use std::time::Instant;
 use winit::{
@@ -106,14 +106,10 @@ fn main() {
     let image = image.to_rgba();
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
-    let lenna_texture_id = renderer.upload_texture(
-        &device,
-        &mut queue,
-        &raw_data,
-        width,
-        height,
-        Some("lenna texture"),
-    );
+
+    let texture = Texture::new(width, height, &device, &renderer, Some("lenna texture"));
+    texture.upload(&queue, &raw_data);
+    let lenna_texture_id = renderer.textures.insert(texture);
 
     let mut last_cursor = None;
 

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -107,8 +107,8 @@ fn main() {
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
 
-    let texture = Texture::new(width, height, &device, &renderer, Some("lenna texture"));
-    texture.upload(&queue, &raw_data);
+    let texture = Texture::new(&device, &renderer, width, height, Some("lenna texture"));
+    texture.write(&queue, &raw_data, width, height);
     let lenna_texture_id = renderer.textures.insert(texture);
 
     let mut last_cursor = None;

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -1,7 +1,7 @@
 use futures::executor::block_on;
 use image::ImageFormat;
 use imgui::*;
-use imgui_wgpu::{Renderer, Texture};
+use imgui_wgpu::{Renderer, Texture, TextureConfig};
 use imgui_winit_support;
 use std::time::Instant;
 use winit::{
@@ -107,7 +107,10 @@ fn main() {
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
 
-    let texture = Texture::new(&device, &renderer, width, height, Some("lenna texture"));
+    let texture = TextureConfig::new(width, height)
+        .set_label("lenna texture")
+        .build(&device, &renderer);
+
     texture.write(&queue, &raw_data, width, height);
     let lenna_texture_id = renderer.textures.insert(texture);
 

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,6 +1,6 @@
 use futures::executor::block_on;
 use imgui::*;
-use imgui_wgpu::Renderer;
+use imgui_wgpu::RendererConfig;
 use imgui_winit_support;
 use std::time::Instant;
 use winit::{
@@ -42,7 +42,7 @@ fn main() {
     }))
     .unwrap();
 
-    let (device, mut queue) = block_on(adapter.request_device(
+    let (device, queue) = block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
             features: wgpu::Features::empty(),
             limits: wgpu::Limits::default(),
@@ -96,10 +96,14 @@ fn main() {
     };
 
     #[cfg(not(feature = "glsl-to-spirv"))]
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
+    let mut renderer = RendererConfig::new()
+        .set_texture_format(sc_desc.format)
+        .build(&mut imgui, &device, &queue);
 
     #[cfg(feature = "glsl-to-spirv")]
-    let mut renderer = Renderer::new_glsl(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
+    let mut renderer = RendererConfig::new_glsl()
+        .set_texture_format(sc_desc.format)
+        .build(&mut imgui, &device, &queue);
 
     let mut last_frame = Instant::now();
     let mut demo_open = true;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -96,7 +96,7 @@ fn main() {
     };
 
     #[cfg(not(feature = "glsl-to-spirv"))]
-    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format);
+    let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
 
     #[cfg(feature = "glsl-to-spirv")]
     let mut renderer = Renderer::new_glsl(&mut imgui, &device, &mut queue, sc_desc.format);

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -99,7 +99,7 @@ fn main() {
     let mut renderer = Renderer::new(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
 
     #[cfg(feature = "glsl-to-spirv")]
-    let mut renderer = Renderer::new_glsl(&mut imgui, &device, &mut queue, sc_desc.format);
+    let mut renderer = Renderer::new_glsl(&mut imgui, &device, &mut queue, sc_desc.format, None, 1);
 
     let mut last_frame = Instant::now();
     let mut demo_open = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,16 @@ impl Texture {
             self.size,
         );
     }
+
+    /// The width of the texture.
+    pub fn width(&self) -> u32 {
+        self.size.width
+    }
+
+    /// The height of the texture.
+    pub fn height(&self) -> u32 {
+        self.size.height
+    }
 }
 
 pub struct Renderer {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,12 +65,12 @@ pub struct Texture {
     bind_group: BindGroup,
     view: wgpu::TextureView,
     width: u32,
-    height: u32
+    height: u32,
 }
 
 impl Texture {
     /// Creates a new GPU texture width the specified `width` and `height`.
-    /// 
+    ///
     /// - `width`: The width of the new texture in pixels.  
     /// - `height`: The height of the new texture in pixels.  
     /// - `label`: Identifies the texture in a debugger.
@@ -135,7 +135,7 @@ impl Texture {
             texture,
             bind_group,
             width: size.width,
-            height: size.height
+            height: size.height,
             view
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,8 +129,8 @@ impl Renderer {
         device: &Device,
         queue: &Queue,
         format: TextureFormat,
-        sample_count: u32,
         depth_format: Option<TextureFormat>,
+        sample_count: u32,
     ) -> Renderer {
         let (vs_code, fs_code) = Shaders::get_program_code();
         let vs_raw = Shaders::compile_glsl(vs_code, ShaderStage::Vertex);


### PR DESCRIPTION
A texture is now represented by the `Texture` struct.
Its texture data can now be uploaded and updated with `Texture::write()`.
Made the `Renderer::textures` field publicly accessible (it's used to manage existing textures).
Changed `Renderer::reload_font_texture()` to take into account possible preuploaded font atlas textures.
Added some documentation to the `Texture` struct and its methods.

I've also incorporated the commit Aeledfyr@af054c9a21524fed4c8746f06473d852af7790e1 (@Aeledfyr I hope it's OK), which enables to pass a depth format and MSAA sample count when creating a new renderer.