### PR TITLE
fix: initial scale factor

### DIFF
--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -372,7 +372,6 @@ fn main() {
 
     // Set up window and GPU
     let event_loop = EventLoop::new();
-    let mut hidpi_factor = 1.0;
 
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 
@@ -391,6 +390,8 @@ fn main() {
 
         (window, size, surface)
     };
+
+    let mut hidpi_factor = window.scale_factor();
 
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -16,7 +16,6 @@ fn main() {
 
     // Set up window and GPU
     let event_loop = EventLoop::new();
-    let mut hidpi_factor = 1.0;
 
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 
@@ -35,6 +34,8 @@ fn main() {
 
         (window, size, surface)
     };
+
+    let mut hidpi_factor = window.scale_factor();
 
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -15,7 +15,6 @@ fn main() {
 
     // Set up window and GPU
     let event_loop = EventLoop::new();
-    let mut hidpi_factor = 1.0;
 
     let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
 
@@ -34,6 +33,8 @@ fn main() {
 
         (window, size, surface)
     };
+
+    let mut hidpi_factor = window.scale_factor();
 
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,


### PR DESCRIPTION
This PR makes examples to obtain initial scale factor correctly. This affect the initialization of font bitmap.

On MacOS,
Before:

![image](https://user-images.githubusercontent.com/1195774/92923022-57ccbb80-f469-11ea-8593-bcf048dd6584.png)

After:

![image](https://user-images.githubusercontent.com/1195774/92922915-27851d00-f469-11ea-8599-aeaae79362ca.png)
