### PR TITLE
Add support for viewports

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,6 +319,9 @@ impl Renderer {
         let width = draw_data.display_size[0];
         let height = draw_data.display_size[1];
 
+        let offset_x = draw_data.display_pos[0] / width;
+        let offset_y = draw_data.display_pos[1] / height;
+
         // Create and update the transform matrix for the current frame.
         // This is required to adapt to vulkan coordinates.
         // let matrix = [
@@ -331,7 +334,7 @@ impl Renderer {
             [2.0 / width, 0.0, 0.0, 0.0],
             [0.0, 2.0 / -height as f32, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
-            [-1.0, 1.0, 0.0, 1.0],
+            [-1.0 - offset_x * 2.0, 1.0 + offset_y * 2.0, 0.0, 1.0],
         ];
         self.update_uniform_buffer(queue, &matrix);
 


### PR DESCRIPTION
That's the only change on imgui-wgpu side necessary to support viewports from docking branch of Dear ImGui.
This change is compatible and works the same with master branch of Dear ImGui and 0.4/0.5 versions of imgui-rs.
![imgui_wgpu_viewports](https://user-images.githubusercontent.com/9898555/94697327-45f08100-0362-11eb-9388-5cb10002f789.gif)