### PR TITLE
fix regression

### DIFF
--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -493,6 +493,8 @@ fn main() {
                 event: WindowEvent::Resized(_),
                 ..
             } => {
+                let size = window.inner_size();
+
                 let sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -141,6 +141,8 @@ fn main() {
                 event: WindowEvent::Resized(_),
                 ..
             } => {
+                let size = window.inner_size();
+
                 let sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -119,6 +119,8 @@ fn main() {
                 event: WindowEvent::Resized(_),
                 ..
             } => {
+                let size = window.inner_size();
+
                 let sc_desc = wgpu::SwapChainDescriptor {
                     usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,


### PR DESCRIPTION
in 59557269bc7eedf97c4b50ee1a168d6fd6ab4360 I removed the size cause I assumed it only had global effect but it was used locally for the new sc descriptor and after the change never got updated values but always saw the global one

closes https://github.com/Yatekii/imgui-wgpu-rs/issues/36 if confirmed 