### PR TITLE
add simple api

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,8 @@ jobs:
       - name: Run cargo test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test 
+          args: --all-features
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ exclude = [
 ]
 
 [features]
-default = []
+# used in src/simple_api.rs
+simple_api_unstable = [ "winit", "futures", "imgui-winit-support" ]
+
+default = ["simple_api_unstable"] # TOOO unset after review, just testing
 
 [dependencies]
 wgpu = "0.6"
@@ -28,6 +31,11 @@ log = "0.4"
 imgui = "0.6"
 bytemuck = "1"
 smallvec = "1"
+
+# deps for simple_api_unstable
+winit = { version = "0.22", optional = true }
+futures = { version = "0.3", optional = true }
+imgui-winit-support = { version = "0.5", default-featues = false, featues = ["winit-22"], optional = true}
 
 [dev-dependencies]
 wgpu-subscriber = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [features]
 # used in src/simple_api.rs
-simple_api_unstable = [ "winit", "futures", "imgui-winit-support" ]
+simple_api_unstable = [ "winit", "pollster", "imgui-winit-support" ]
 
 default = []
 
@@ -34,7 +34,7 @@ smallvec = "1"
 
 # deps for simple_api_unstable
 winit = { version = "0.22", optional = true }
-futures = { version = "0.3", optional = true }
+pollster = { version = "0.2.0", optional = true } # for block_on executor
 imgui-winit-support = { version = "0.5", default-featues = false, featues = ["winit-22"], optional = true}
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,12 @@ image = "0.23"
 futures = "0.3"
 cgmath = "0.17"
 bytemuck = { version = "1.4", features = ["derive"] }
-imgui-winit-support = "0.6"
+implot = "*"
+
+[dev-dependencies.imgui-winit-support]
+version = "0.5"
+default-features = false
+features = ["winit-22"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ bytemuck = "1"
 smallvec = "1"
 
 # deps for simple_api_unstable
-winit = { version = "0.22", optional = true }
+winit = { version = "0.23", optional = true }
 pollster = { version = "0.2.0", optional = true } # for block_on executor
-imgui-winit-support = { version = "0.5", default-featues = false, featues = ["winit-22"], optional = true}
+imgui-winit-support = { version = "0.6", optional = true }
 
 [dev-dependencies]
 wgpu-subscriber = "0.1"
@@ -45,12 +45,6 @@ image = "0.23"
 futures = "0.3"
 cgmath = "0.17"
 bytemuck = { version = "1.4", features = ["derive"] }
-implot = { version = "0.2", git = "https://github.com/4bb4/implot-rs" } # not published yet
-
-[dev-dependencies.imgui-winit-support]
-version = "0.5"
-default-features = false
-features = ["winit-22"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 # used in src/simple_api.rs
 simple_api_unstable = [ "winit", "futures", "imgui-winit-support" ]
 
-default = ["simple_api_unstable"] # TOOO unset after review, just testing
+default = []
 
 [dependencies]
 wgpu = "0.6"
@@ -45,7 +45,7 @@ image = "0.23"
 futures = "0.3"
 cgmath = "0.17"
 bytemuck = { version = "1.4", features = ["derive"] }
-implot = "*"
+implot = { version = "0.2", git = "https://github.com/4bb4/implot-rs" } # not published yet
 
 [dev-dependencies.imgui-winit-support]
 version = "0.5"

--- a/examples/basic_simple_api.rs
+++ b/examples/basic_simple_api.rs
@@ -1,0 +1,7 @@
+fn main() {
+    imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
+        imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {
+            ui.text(imgui::im_str!("Hello world!"));
+        });
+    });
+}

--- a/examples/basic_simple_api.rs
+++ b/examples/basic_simple_api.rs
@@ -3,7 +3,7 @@
 
 fn main() {
     imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
-        imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {
+        imgui::Window::new(imgui::im_str!("hello world")).build(&ui, || {
             ui.text(imgui::im_str!("Hello world!"));
         });
     });

--- a/examples/basic_simple_api.rs
+++ b/examples/basic_simple_api.rs
@@ -1,3 +1,6 @@
+// you need to set --feature=simple_api_unstable to run this example
+// cargo run --example basic_simple_api --features=simple_api_unstable
+
 fn main() {
     imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
         imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -108,7 +108,7 @@ fn main() {
     let lenna_bytes = include_bytes!("../resources/Lenna.jpg");
     let image =
         image::load_from_memory_with_format(lenna_bytes, ImageFormat::Jpeg).expect("invalid image");
-    let image = image.to_bgra();
+    let image = image.to_bgra8();
     let (width, height) = image.dimensions();
     let raw_data = image.into_raw();
 

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -1,3 +1,6 @@
+// you need to set --feature=simple_api_unstable to run this example
+// cargo run --example fullscreen_simple_api --features=simple_api_unstable
+
 use imgui::{im_str, Condition};
 use imgui_wgpu::simple_api;
 
@@ -47,22 +50,22 @@ fn main() {
             .build(&ui, || {
                 ui.text(im_str!("Hello world!"));
 
-                // begin implot
-                let plot_ui = &state.plotcontext.get_plot_ui();
+                // implot example
+                {
+                    let plot_ui = &state.plotcontext.get_plot_ui();
 
-                let content_width = ui.window_content_region_width();
-                implot::Plot::new("Simple line plot")
-                    // The size call could also be omitted, though the defaults don't consider window
-                    // width, which is why we're not doing so here.
-                    .size(content_width, 300.0)
-                    .build(plot_ui, || {
-                        // If this is called outside a plot build callback, the program will panic.
-                        let x_positions = vec![0.1, 0.9];
-                        let y_positions = vec![0.1, 0.9];
-                        implot::PlotLine::new("legend label").plot(&x_positions, &y_positions);
-                    });
-
-                // end implot
+                    let content_width = ui.window_content_region_width();
+                    implot::Plot::new("Simple line plot")
+                        // The size call could also be omitted, though the defaults don't consider window
+                        // width, which is why we're not doing so here.
+                        .size(content_width, 300.0)
+                        .build(plot_ui, || {
+                            // If this is called outside a plot build callback, the program will panic.
+                            let x_positions = vec![0.1, 0.9];
+                            let y_positions = vec![0.1, 0.9];
+                            implot::PlotLine::new("legend label").plot(&x_positions, &y_positions);
+                        });
+                }
             });
 
         state.last_frame = now;

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -8,7 +8,7 @@ struct State {
     last_frame: std::time::Instant,
     height: f32,
     width: f32,
-    highdpi_factor: f64,
+    high_dpi_factor: f64,
     plotcontext: implot::Context,
 }
 
@@ -17,7 +17,7 @@ fn main() {
         on_resize: &|input, state: &mut State, hdpi| {
             state.height = input.height as f32;
             state.width = input.width as f32;
-            state.highdpi_factor = hdpi;
+            state.high_dpi_factor = hdpi;
         },
         ..Default::default()
     };
@@ -28,7 +28,7 @@ fn main() {
         last_frame: std::time::Instant::now(),
         height: 100.0,
         width: 100.0,
-        highdpi_factor: 2.0,
+        high_dpi_factor: 2.0,
         plotcontext,
     };
 
@@ -41,8 +41,8 @@ fn main() {
             .resizable(false)
             .size(
                 [
-                    state.width / state.highdpi_factor as f32,
-                    state.height / state.highdpi_factor as f32,
+                    state.width / state.high_dpi_factor as f32,
+                    state.height / state.high_dpi_factor as f32,
                 ],
                 Condition::Always,
             )

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -9,7 +9,6 @@ struct State {
     height: f32,
     width: f32,
     high_dpi_factor: f64,
-    plotcontext: implot::Context,
 }
 
 fn main() {
@@ -22,14 +21,11 @@ fn main() {
         ..Default::default()
     };
 
-    let plotcontext = implot::Context::create();
-
     let state = State {
         last_frame: std::time::Instant::now(),
         height: 100.0,
         width: 100.0,
         high_dpi_factor: 2.0,
-        plotcontext,
     };
 
     imgui_wgpu::simple_api::run(config, state, |ui, state| {
@@ -49,23 +45,6 @@ fn main() {
             .menu_bar(true)
             .build(&ui, || {
                 ui.text(im_str!("Hello world!"));
-
-                // implot example
-                {
-                    let plot_ui = &state.plotcontext.get_plot_ui();
-
-                    let content_width = ui.window_content_region_width();
-                    implot::Plot::new("Simple line plot")
-                        // The size call could also be omitted, though the defaults don't consider window
-                        // width, which is why we're not doing so here.
-                        .size(content_width, 300.0)
-                        .build(plot_ui, || {
-                            // If this is called outside a plot build callback, the program will panic.
-                            let x_positions = vec![0.1, 0.9];
-                            let y_positions = vec![0.1, 0.9];
-                            implot::PlotLine::new("legend label").plot(&x_positions, &y_positions);
-                        });
-                }
             });
 
         state.last_frame = now;

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -1,0 +1,50 @@
+use imgui::{im_str, Condition};
+use imgui_wgpu::simple_api;
+
+#[derive(Debug)]
+struct State {
+    last_frame: std::time::Instant,
+    height: f32,
+    width: f32,
+    highdpi_factor: f64,
+}
+
+fn main() {
+    let config = simple_api::Config {
+        on_resize: &|input, state: &mut State, hdpi| {
+            state.height = input.height as f32;
+            state.width = input.width as f32;
+            state.highdpi_factor = hdpi;
+        },
+        ..Default::default()
+    };
+
+    let state = State {
+        last_frame: std::time::Instant::now(),
+        height: 100.0,
+        width: 100.0,
+        highdpi_factor: 2.0,
+    };
+
+    imgui_wgpu::simple_api::run(config, state, |ui, state| {
+        let now = std::time::Instant::now();
+
+        imgui::Window::new(im_str!("full-window example"))
+            .position([0.0, 0.0], Condition::Always)
+            .collapsible(false)
+            .resizable(false)
+            .size(
+                [
+                    state.width / state.highdpi_factor as f32,
+                    state.height / state.highdpi_factor as f32,
+                ],
+                Condition::Always,
+            )
+            .menu_bar(true)
+            .build(&ui, || {
+                ui.text(im_str!("Hello world!"));
+            });
+
+        state.last_frame = now;
+    });
+}

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -1,12 +1,12 @@
 use imgui::{im_str, Condition};
 use imgui_wgpu::simple_api;
 
-#[derive(Debug)]
 struct State {
     last_frame: std::time::Instant,
     height: f32,
     width: f32,
     highdpi_factor: f64,
+    plotcontext: implot::Context,
 }
 
 fn main() {
@@ -19,11 +19,14 @@ fn main() {
         ..Default::default()
     };
 
+    let plotcontext = implot::Context::create();
+
     let state = State {
         last_frame: std::time::Instant::now(),
         height: 100.0,
         width: 100.0,
         highdpi_factor: 2.0,
+        plotcontext,
     };
 
     imgui_wgpu::simple_api::run(config, state, |ui, state| {
@@ -43,6 +46,23 @@ fn main() {
             .menu_bar(true)
             .build(&ui, || {
                 ui.text(im_str!("Hello world!"));
+
+                // begin implot
+                let plot_ui = &state.plotcontext.get_plot_ui();
+
+                let content_width = ui.window_content_region_width();
+                implot::Plot::new("Simple line plot")
+                    // The size call could also be omitted, though the defaults don't consider window
+                    // width, which is why we're not doing so here.
+                    .size(content_width, 300.0)
+                    .build(plot_ui, || {
+                        // If this is called outside a plot build callback, the program will panic.
+                        let x_positions = vec![0.1, 0.9];
+                        let y_positions = vec![0.1, 0.9];
+                        implot::PlotLine::new("legend label").plot(&x_positions, &y_positions);
+                    });
+
+                // end implot
             });
 
         state.last_frame = now;

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -42,15 +42,8 @@ fn main() {
     }))
     .unwrap();
 
-    let (device, queue) = block_on(adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            features: wgpu::Features::empty(),
-            limits: wgpu::Limits::default(),
-            shader_validation: false,
-        },
-        None,
-    ))
-    .unwrap();
+    let (device, queue) =
+        block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None)).unwrap();
 
     // Set up swap chain
     let sc_desc = wgpu::SwapChainDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use wgpu::*;
 
 pub type RendererResult<T> = Result<T, RendererError>;
 
+#[cfg(feature = "simple_api_unstable")]
+pub mod simple_api;
+
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone)]
 struct DrawVertPod(DrawVert);

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -1,0 +1,267 @@
+/*!
+A simple API to get an imgui context in only a few lines of code.
+
+
+This API only provides stability on a best efforts basis because its meant for small/ temporary projects like if you need to quickly plot something
+and just need a context do do some imgui work.
+
+It aims to make updating the wgpu imgui bindings easier as it abstracts all the setup. This comes with the drawback of yet another API.
+
+It is basically a wrapper around the hello world example with a few customization options.
+
+The API consists of a Config which you may not need to touch and just use the Default one.
+Optionally you can additionally provide you own Struct to have mutable state for you small application.
+
+```rust
+fn main() {
+    imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
+        imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {
+            ui.text(imgui::im_str!("Hello world!"));
+        });
+    });
+}
+```
+*/
+
+use crate::{Renderer, RendererConfig};
+use futures::executor::block_on;
+use imgui::*;
+
+use std::time::Instant;
+use winit::{
+    dpi::LogicalSize,
+    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event_loop::{ControlFlow, EventLoop},
+    window::Window,
+};
+
+/// use `Default::default` if you don't need anything specific.
+pub struct Config<State: 'static> {
+    /// name of the window
+    pub window_title: String,
+    /// can be used to resize the window
+    pub initial_window_width: f32,
+    /// can be used to resize the window
+    pub initial_window_height: f32,
+    /// if you want to adjust your imgui window to match the size of the outer window
+    /// this makes it possible to have a "fullscreen" imgui window spanning the whole current window.
+    pub on_resize: &'static dyn Fn(&winit::dpi::PhysicalSize<u32>, &mut State, f64),
+    /// called after the premade events have been handled which includes close request
+    /// if you think you need to handle this, this api abstraction is probably to high level
+    /// and you may want to copy the code from hello_world.rs and adapt directly
+    pub on_event: &'static dyn Fn(&winit::event::WindowEvent<'_>, &mut State),
+    /// font size
+    pub font_size: Option<f32>,
+    /// color that fills the window
+    pub background_color: wgpu::Color,
+}
+
+impl<State> Default for Config<State> {
+    fn default() -> Self {
+        Self {
+            window_title: "imgui".to_string(),
+            initial_window_width: 1200.0,
+            initial_window_height: 720.0,
+            on_resize: &|_, _, _| {},
+            on_event: &|_, _| {},
+            font_size: None,
+            background_color: wgpu::Color {
+                r: 0.0,
+                g: 0.0,
+                b: 0.0,
+                a: 1.0,
+            },
+        }
+    }
+}
+
+/// simple function to draw imgui
+pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourState)>(
+    config: Config<YourState>,
+    mut state: YourState,
+    render_ui: UiFunction,
+) {
+    // Set up window and GPU
+    let event_loop = EventLoop::new();
+
+    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+
+    let (window, size, surface) = {
+        let window = Window::new(&event_loop).unwrap();
+        window.set_inner_size(LogicalSize {
+            width: config.initial_window_width,
+            height: config.initial_window_height,
+        });
+        window.set_title(&format!("{}", config.window_title));
+        let size = window.inner_size();
+
+        let surface = unsafe { instance.create_surface(&window) };
+
+        (window, size, surface)
+    };
+
+    let hidpi_factor = window.scale_factor();
+
+    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: Some(&surface),
+    }))
+    .unwrap();
+
+    let (device, queue) = block_on(adapter.request_device(
+        &wgpu::DeviceDescriptor {
+            features: wgpu::Features::empty(),
+            limits: wgpu::Limits::default(),
+            shader_validation: false,
+        },
+        None,
+    ))
+    .unwrap();
+
+    // Set up swap chain
+    let sc_desc = wgpu::SwapChainDescriptor {
+        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+        width: size.width as u32,
+        height: size.height as u32,
+        present_mode: wgpu::PresentMode::Mailbox,
+    };
+
+    let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
+
+    // Set up dear imgui
+    let mut imgui = imgui::Context::create();
+    let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
+    platform.attach_window(
+        imgui.io_mut(),
+        &window,
+        imgui_winit_support::HiDpiMode::Default,
+    );
+    imgui.set_ini_filename(None);
+
+    let font_size = config.font_size.unwrap_or((13.0 * hidpi_factor) as f32);
+    imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
+
+    imgui.fonts().add_font(&[FontSource::DefaultFontData {
+        config: Some(imgui::FontConfig {
+            oversample_h: 1,
+            pixel_snap_h: true,
+            size_pixels: font_size,
+            ..Default::default()
+        }),
+    }]);
+
+    //
+    // Set up dear imgui wgpu renderer
+    //
+    let renderer_config = RendererConfig {
+        texture_format: sc_desc.format,
+        ..Default::default()
+    };
+
+    let mut renderer = Renderer::new(&mut imgui, &device, &queue, renderer_config);
+
+    let mut last_frame = Instant::now();
+
+    let mut last_cursor = None;
+
+    // Event loop
+    event_loop.run(move |event, _, control_flow| {
+        *control_flow = ControlFlow::Poll;
+
+        match event {
+            Event::WindowEvent {
+                event: WindowEvent::Resized(_),
+                ..
+            } => {
+                let size = window.inner_size();
+
+                let sc_desc = wgpu::SwapChainDescriptor {
+                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    width: size.width as u32,
+                    height: size.height as u32,
+                    present_mode: wgpu::PresentMode::Mailbox,
+                };
+
+                swap_chain = device.create_swap_chain(&surface, &sc_desc);
+
+                (config.on_resize)(&size, &mut state, hidpi_factor);
+            }
+            Event::WindowEvent {
+                event:
+                    WindowEvent::KeyboardInput {
+                        input:
+                            KeyboardInput {
+                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                                state: ElementState::Pressed,
+                                ..
+                            },
+                        ..
+                    },
+                ..
+            }
+            | Event::WindowEvent {
+                event: WindowEvent::CloseRequested,
+                ..
+            } => {
+                *control_flow = ControlFlow::Exit;
+            }
+
+            Event::MainEventsCleared => window.request_redraw(),
+            Event::RedrawEventsCleared => {
+                let now = Instant::now();
+                imgui.io_mut().update_delta_time(now - last_frame);
+                last_frame = now;
+
+                let frame = match swap_chain.get_current_frame() {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        eprintln!("dropped frame: {:?}", e);
+                        return;
+                    }
+                };
+                platform
+                    .prepare_frame(imgui.io_mut(), &window)
+                    .expect("Failed to prepare frame");
+                let ui = imgui.frame();
+
+                render_ui(&ui, &mut state);
+
+                let mut encoder: wgpu::CommandEncoder =
+                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                if last_cursor != Some(ui.mouse_cursor()) {
+                    last_cursor = Some(ui.mouse_cursor());
+                    platform.prepare_render(&ui, &window);
+                }
+
+                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
+                        attachment: &frame.output.view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(config.background_color),
+                            store: true,
+                        },
+                    }],
+                    depth_stencil_attachment: None,
+                });
+
+                renderer
+                    .render(ui.render(), &queue, &device, &mut rpass)
+                    .expect("Rendering failed");
+
+                drop(rpass);
+
+                queue.submit(Some(encoder.finish()));
+            }
+            Event::WindowEvent { ref event, .. } => {
+                (config.on_event)(event, &mut state);
+            }
+            _ => (),
+        }
+
+        platform.handle_event(imgui.io_mut(), &window, &event);
+    });
+}

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -12,7 +12,7 @@ It is basically a wrapper around the hello world example with a few customizatio
 The API consists of a Config which you may not need to touch and just use the Default one.
 Optionally you can additionally provide you own Struct to have mutable state for you small application.
 
-```rust
+```no_run
 fn main() {
     imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
         imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {


### PR DESCRIPTION
Motivation:
- I end up copying the hello world example in multiple places.
- Implot works very well but to make it as easy to use as e..g matplotlib. a simple way to create a context to use imgui in would be helpful. 

Hello World with this api becomes:
```rust
fn main() {
    imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
        imgui::Window::new(imgui::im_str!("hwllo world")).build(&ui, || {
            ui.text(imgui::im_str!("Hello world!"));
        });
    });
}
```

This API pulls in additional dependencies like winit so I added it under a feature flag which makes clear that API stability is not guaranteed to make maintenance easier and updating dependencies easier. Note that even if this breaks users code its still easier for the common case where it does not break and the existing copy paste option still exists if it breaks in a way the user can't fix immediately. Thus I think this is an improvement over the current state.

Maintenance should be fairly easy as its basically a copy of hello world with slight modifications. 
Doing this maintenance in one place makes it easier for users to update imgui-wgpu versions because they don't have to handle that API directly for simple cases (I myself have multiple small projects already where I end up fixing the same things repeatedly).

The config struct supports use cases which I would personally want and could potentially be expanded a bit.
There is an inflection point where this simple API is the wrong level of abstraction though, its only supposed to be used for simple projects and also examples.

Feedback is very much welcome and wanted.