### PR TITLE
Support winit 0.24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to cargo's version of [Semantic Versioning](https://sem
 
 ## Unreleased
 #### Updated
-- `winit` to `0.24`
+- support `winit` 0.24 as well as 0.23
 
 ## v0.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to cargo's version of [Semantic Versioning](https://sem
 - [Diffs](#diffs)
 
 ## Unreleased
+#### Updated
+- `winit` to `0.24`
 
 ## v0.12.0
 
@@ -17,8 +19,8 @@ Released 2020-11-21
 
 #### Added
 - A changelog!
-- Shaders are now SRGB aware. Choose `RendererConfig::new()` to get shaders outputting in linear color 
-  and `RendererConfig::new_srgb()` for shaders outputting SRGB.	
+- Shaders are now SRGB aware. Choose `RendererConfig::new()` to get shaders outputting in linear color
+  and `RendererConfig::new_srgb()` for shaders outputting SRGB.
 
 #### Updated
 - `imgui` to `0.6`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,13 +33,14 @@ bytemuck = "1"
 smallvec = "1"
 
 # deps for simple_api_unstable
-winit = { version = "0.23", optional = true }
+winit = { version = "0.24", optional = true }
 pollster = { version = "0.2.0", optional = true } # for block_on executor
 imgui-winit-support = { version = "0.6", optional = true }
 
 [dev-dependencies]
 wgpu-subscriber = "0.1"
-winit = "0.23"
+winit = "0.24"
+imgui-winit-support = "0.6"
 raw-window-handle = "0.3"
 image = "0.23"
 futures = "0.3"
@@ -49,5 +50,7 @@ bytemuck = { version = "1.4", features = ["derive"] }
 [package.metadata.docs.rs]
 all-features = true
 
-# [patch.crates-io]
+[patch.crates-io]
 # wgpu = { version = "0.4", git = "https://github.com/gfx-rs/wgpu-rs.git", rev = "7b15e24" }
+imgui = { version = "0.6", git = "https://github.com/willemv/imgui-rs.git", rev = "8f924da7595ba" }
+imgui-winit-support = { version = "0.6", git = "https://github.com/willemv/imgui-rs.git", rev = "8f924da7595ba" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ bytemuck = "1"
 smallvec = "1"
 
 # deps for simple_api_unstable
-winit = { version = "0.24", optional = true }
+winit = { version = ">= 0.23, < 0.25", optional = true }
 pollster = { version = "0.2.0", optional = true } # for block_on executor
 imgui-winit-support = { version = "0.6", optional = true }
 
@@ -50,7 +50,5 @@ bytemuck = { version = "1.4", features = ["derive"] }
 [package.metadata.docs.rs]
 all-features = true
 
-[patch.crates-io]
+# [patch.crates-io]
 # wgpu = { version = "0.4", git = "https://github.com/gfx-rs/wgpu-rs.git", rev = "7b15e24" }
-imgui = { version = "0.6", git = "https://github.com/willemv/imgui-rs.git", rev = "8f924da7595ba" }
-imgui-winit-support = { version = "0.6", git = "https://github.com/willemv/imgui-rs.git", rev = "8f924da7595ba" }

--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ cargo run --release --example hello_world
 
 # Status
 
-Basic features are useable. Uses `wgpu-0.6.0` and `imgui-0.6.0` upstream. `winit-0.23` is used with the examples.
+Basic features are useable. Uses `wgpu-0.6.0` and `imgui-0.6.0` upstream. `winit-0.24` is used with the examples.
 
 Contributions are very welcome.

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,3 +1,5 @@
+extern crate imgui_winit_support;
+
 use futures::executor::block_on;
 use imgui::*;
 use imgui_wgpu::{Renderer, RendererConfig};


### PR DESCRIPTION
Updating winit dependency to 0.24.

Needs a new release of the `imgui-winit-support` crate first, which in turn needs a new release of `glium`. See https://github.com/imgui-rs/imgui-rs/pull/404

Marking this PR as draft until both have a new release on crates.io