### PR TITLE
Update to wgpu 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 and this project adheres to cargo's version of [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - [Unreleased](#unreleased)
+- [v0.13.0](#v0130)
 - [v0.12.0](#v0120)
 - [Diffs](#diffs)
 
 ## Unreleased
+
+## v0.13.0
+
+Released 2021-02-01
+
+#### Added
+- Add experimental simple api behind feature `simple_api_unstable`
+- Implemented `std::error::Error` for `RendererError`
+
 #### Updated
+- updated to `wgpu` 0.7
 - support `winit` 0.24 as well as 0.23
 
 ## v0.12.0
@@ -31,5 +42,6 @@ Released 2020-11-21
 
 ## Diffs
 
-- [Unreleased](https://github.com/Yatekii/imgui-wgpu-rs/compare/v0.12.0...HEAD)
+- [Unreleased](https://github.com/Yatekii/imgui-wgpu-rs/compare/v0.13.0...HEAD)
+- [v0.13.0](https://github.com/Yatekii/imgui-wgpu-rs/compare/v0.12.0...v0.13.0)
 - [v0.12.0](https://github.com/Yatekii/imgui-wgpu-rs/compare/v0.11.0...v0.12.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,26 +26,26 @@ simple_api_unstable = [ "winit", "pollster", "imgui-winit-support" ]
 default = []
 
 [dependencies]
-wgpu = "0.6"
-log = "0.4"
-imgui = "0.6"
 bytemuck = "1"
+imgui = "0.6"
+log = "0.4"
 smallvec = "1"
+wgpu = "0.7"
 
 # deps for simple_api_unstable
-winit = { version = ">= 0.23, < 0.25", optional = true }
-pollster = { version = "0.2.0", optional = true } # for block_on executor
 imgui-winit-support = { version = "0.6", optional = true }
+pollster = { version = "0.2.0", optional = true } # for block_on executor
+winit = { version = ">= 0.23, < 0.25", optional = true }
 
 [dev-dependencies]
-wgpu-subscriber = "0.1"
-winit = "0.24"
+bytemuck = { version = "1.4", features = ["derive"] }
+cgmath = "0.17"
+futures = "0.3"
+image = "0.23"
 imgui-winit-support = "0.6"
 raw-window-handle = "0.3"
-image = "0.23"
-futures = "0.3"
-cgmath = "0.17"
-bytemuck = { version = "1.4", features = ["derive"] }
+wgpu-subscriber = "0.1"
+winit = "0.24"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "imgui-wgpu"
-version = "0.12.0"
-authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Steven Wittens <steven@acko.net>"]
+version = "0.13.0"
+authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Connor Fitzgerald <connorwadefitzgerald@gmail.com>", "Steven Wittens <steven@acko.net>"]
 edition = "2018"
 description = "A wgpu render backend for imgui-rs."
 documentation = "https://docs.rs/imgui-wgpu/"

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -45,9 +45,9 @@ fn main() {
 
     let (device, queue) = block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
+            label: None,
             features: wgpu::Features::empty(),
             limits: wgpu::Limits::default(),
-            shader_validation: false,
         },
         None,
     ))
@@ -55,7 +55,7 @@ fn main() {
 
     // Set up swap chain
     let sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         width: size.width as u32,
         height: size.height as u32,
@@ -144,7 +144,7 @@ fn main() {
                 let size = window.inner_size();
 
                 let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     width: size.width as u32,
                     height: size.height as u32,
@@ -213,6 +213,7 @@ fn main() {
                 }
 
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
                     color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: &frame.output.view,
                         resolve_target: None,

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -49,7 +49,7 @@ fn main() {
 
     // Set up swap chain
     let sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         width: size.width as u32,
         height: size.height as u32,
@@ -117,7 +117,7 @@ fn main() {
                 let size = window.inner_size();
 
                 let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     width: size.width as u32,
                     height: size.height as u32,
@@ -200,6 +200,7 @@ fn main() {
                 }
 
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
                     color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: &frame.output.view,
                         resolve_target: None,

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -113,7 +113,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
 
     // Set up swap chain
     let sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         width: size.width as u32,
         height: size.height as u32,
@@ -171,7 +171,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
                 let size = window.inner_size();
 
                 let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
+                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     width: size.width as u32,
                     height: size.height as u32,
@@ -231,6 +231,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
                 }
 
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
                     color_attachments: &[wgpu::RenderPassColorAttachmentDescriptor {
                         attachment: &frame.output.view,
                         resolve_target: None,


### PR DESCRIPTION
This bumps version to `0.13` and includes support for wgpu `0.7`. No API changes beyond what was already merged.