### PR TITLE
Update imgui dependency to version 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,13 +27,13 @@ default = []
 
 [dependencies]
 bytemuck = "1"
-imgui = "0.6"
+imgui = "0.7"
 log = "0.4"
 smallvec = "1"
 wgpu = "0.7"
 
 # deps for simple_api_unstable
-imgui-winit-support = { version = "0.6", optional = true }
+imgui-winit-support = { version = "0.7", optional = true }
 pollster = { version = "0.2.0", optional = true } # for block_on executor
 winit = { version = ">= 0.23, < 0.25", optional = true }
 
@@ -42,7 +42,7 @@ bytemuck = { version = "1.4", features = ["derive"] }
 cgmath = "0.17"
 futures = "0.3"
 image = "0.23"
-imgui-winit-support = "0.6"
+imgui-winit-support = "0.7"
 raw-window-handle = "0.3"
 wgpu-subscriber = "0.1"
 winit = "0.24"


### PR DESCRIPTION
Hi there,

I use `imgui-wgpu-rs` over at https://github.com/4bb4/implot-rs, and after the recent upgrade of `imgui-rs` to 0.7, I'd like to also use the WGPU with it. I hence tried out bumping the versions in `imgui-wgpu-rs` and things seem to work somewhat (the code builds, anyway). Let me know what you think.

One thing I did encounter in my example code that uses WGPU (https://github.com/4bb4/implot-rs/tree/13-upgrade-to-imgui-rs-0.7/implot-examples/implot-wgpu-demo) is that once I point things to `wgpu` 0.7 and the version of `imgui-wgpu-rs` that is the source of this PR, things run, but once I scroll around a bit in a window, I get a panic:

```
wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 641, Vulkan)>`
    In a set_scissor_rect command
    Invalid ScissorRect parameters


thread 'main' panicked at 'Handling wgpu errors as fatal by default', .../.cargo/registry/src/github.com-1ecc6299db9ec823/wgpu-0.7.0/src/backend/direct.rs:1896:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `1`,
 right: `0`: Allocator dropped before all sets were deallocated', .../.cargo/registry/src/github.com-1ecc6299db9ec823/gpu-descriptor-0.1.0/src/allocator.rs:117:9

```
I'm not expecting anyone to fix my problems for me, but I thought this might be a problem not specific to my example but rather with just bumping versions like I do in this PR. I can provide a full stack trace or try other stuff as well if desired.
