### PR TITLE
allow imgui context creation in simple_api before run loop starts

### DIFF
--- a/examples/basic_simple_api.rs
+++ b/examples/basic_simple_api.rs
@@ -2,7 +2,7 @@
 // cargo run --example basic_simple_api --features=simple_api_unstable
 
 fn main() {
-    imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
+    imgui_wgpu::simple_api::run(imgui::Context::create(), Default::default(), (), |ui, _| {
         imgui::Window::new(imgui::im_str!("hello world")).build(&ui, || {
             ui.text(imgui::im_str!("Hello world!"));
         });

--- a/examples/fullscreen_simple_api.rs
+++ b/examples/fullscreen_simple_api.rs
@@ -28,7 +28,10 @@ fn main() {
         high_dpi_factor: 2.0,
     };
 
-    imgui_wgpu::simple_api::run(config, state, |ui, state| {
+    let imgui = imgui::Context::create();
+    // setup imnodes/ implot context as needed, it can depend on the imgui context being created first
+
+    imgui_wgpu::simple_api::run(imgui, config, state, |ui, state| {
         let now = std::time::Instant::now();
 
         imgui::Window::new(im_str!("full-window example"))

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -36,10 +36,7 @@ use winit::{
 };
 
 /// use `Default::default` if you don't need anything specific.
-/// creating the Config initializes the imgui context such that plugins which rely on it can be initialized as well
 pub struct Config<State: 'static> {
-    /// imgui cotext
-    pub imgui: imgui::Context,
     /// name of the window
     pub window_title: String,
     /// can be used to resize the window
@@ -62,7 +59,6 @@ pub struct Config<State: 'static> {
 impl<State> Default for Config<State> {
     fn default() -> Self {
         Self {
-            imgui: imgui::Context::create(),
             window_title: "imgui".to_string(),
             initial_window_width: 1200.0,
             initial_window_height: 720.0,
@@ -81,6 +77,7 @@ impl<State> Default for Config<State> {
 
 /// simple function to draw imgui
 pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourState)>(
+    mut imgui: imgui::Context,
     config: Config<YourState>,
     mut state: YourState,
     render_ui: UiFunction,
@@ -128,7 +125,6 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
     let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
 
     // Set up dear imgui
-    let mut imgui = config.imgui;
     let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
     platform.attach_window(
         imgui.io_mut(),

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -36,7 +36,10 @@ use winit::{
 };
 
 /// use `Default::default` if you don't need anything specific.
+/// creating the Config initializes the imgui context such that plugins which rely on it can be initialized as well
 pub struct Config<State: 'static> {
+    /// imgui cotext
+    pub imgui: imgui::Context,
     /// name of the window
     pub window_title: String,
     /// can be used to resize the window
@@ -59,6 +62,7 @@ pub struct Config<State: 'static> {
 impl<State> Default for Config<State> {
     fn default() -> Self {
         Self {
+            imgui: imgui::Context::create(),
             window_title: "imgui".to_string(),
             initial_window_width: 1200.0,
             initial_window_height: 720.0,
@@ -124,7 +128,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
     let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
 
     // Set up dear imgui
-    let mut imgui = imgui::Context::create();
+    let mut imgui = config.imgui;
     let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
     platform.attach_window(
         imgui.io_mut(),

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -14,7 +14,7 @@ Optionally, you can provide your own Struct to have a place to store mutable sta
 
 ```no_run
 fn main() {
-    imgui_wgpu::simple_api::run(Default::default(), (), |ui, _| {
+    imgui_wgpu::simple_api::run(imgui::Context::create(), Default::default(), (), |ui, _| {
         imgui::Window::new(imgui::im_str!("hello world")).build(&ui, || {
             ui.text(imgui::im_str!("Hello world!"));
         });


### PR DESCRIPTION
ref https://github.com/Nelarius/imnodes/issues/79

I think this is a better solution as it might be usefull for more plugins

I'm not sure if I can make the imgui context part of the Context (see first commit)/ did not manage to appease the borrow checker. I can make it one commit if approved :) 

I tested this with imnodes and it solves the problem.