### PR TITLE
Fix multisampling for wgpu 0.9

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,7 +413,7 @@ impl Renderer {
             }),
             multisample: MultisampleState {
                 count: sample_count,
-                .. Default::default()
+                ..Default::default()
             },
             fragment: Some(FragmentState {
                 module: &fs_module,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -411,7 +411,10 @@ impl Renderer {
                 stencil: wgpu::StencilState::default(),
                 bias: DepthBiasState::default(),
             }),
-            multisample: MultisampleState::default(),
+            multisample: MultisampleState {
+                count: sample_count,
+                .. Default::default()
+            },
             fragment: Some(FragmentState {
                 module: &fs_module,
                 entry_point: "main",


### PR DESCRIPTION
Pass on the sample_count value to the new MultisampleState parameter of the render pipeline.
