### PR TITLE
Do not perform scissor if outside framebuffer (fixes `Invalid ScissorRect parameters`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 #### Fixed
 - Internal: fix all warnings from static analysis (clippy).
+- Internal: Do not render draw commands that fall outside the framebuffer
 
 ## v0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 #### Fixed
 - Internal: fix all warnings from static analysis (clippy).
 - Internal: Do not render draw commands that fall outside the framebuffer
+- Internal: Avoid wgpu logic error by not rendering empty clip rects
 
 ## v0.16.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -577,10 +577,17 @@ impl Renderer {
                         (clip_rect[3] - clip_rect[1]).abs().ceil() as u32,
                     );
 
-                    rpass.set_scissor_rect(scissors.0, scissors.1, scissors.2, scissors.3);
+                    // XXX: Work-around for wgpu issue [1] by only issuing draw
+                    // calls if the scissor rect is valid (by wgpu's flawed
+                    // logic). Regardless, a zero-width or zero-height scissor
+                    // is essentially a no-op render anyway, so just skip it.
+                    // [1]: https://github.com/gfx-rs/wgpu/issues/1750
+                    if scissors.2 > 0 && scissors.3 > 0 {
+                        rpass.set_scissor_rect(scissors.0, scissors.1, scissors.2, scissors.3);
 
-                    // Draw the current batch of vertices with the renderpass.
-                    rpass.draw_indexed(start..end, 0, 0..1);
+                        // Draw the current batch of vertices with the renderpass.
+                        rpass.draw_indexed(start..end, 0, 0..1);
+                    }
                 }
 
                 // Increment the index regardless of whether or not this batch


### PR DESCRIPTION
## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
In the `hello_world` example, I can cause a crash by expanding the "Help" section and then resizing the window (the window manager window, not the imgui window) down very small. The crash is caused by the scissor rect extending beyond the framebuffer dimensions.

This PR adds a check for this which is present in both the standard C++ imgui backends (see [here](https://github.com/ocornut/imgui/blob/cf2daf353ebffdc84e081b76fe5112776af8a1f4/backends/imgui_impl_opengl3.cpp#L478)), and in the imgui-rs gfx backend [here](https://github.com/imgui-rs/imgui-rs/blob/master/imgui-gfx-renderer/src/lib.rs#L269).

## Related Issues
I believe this fixes some of the crashes mentioned in #53 but not all of them. Check this issue on wgpu for more info on a complete fix: https://github.com/gfx-rs/wgpu/issues/1750
