### PR TITLE
Upgrade to wpgu 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Unreleased
 
+#### Updated
+- updated `wgpu` to 0.10
+
 #### Fixed
 - Internal: fix all warnings from static analysis (clippy).
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ readme = "README.md"
 categories = ["gui", "graphics", "rendering", "rendering::graphics-api"]
 keywords = ["gui", "graphics", "wgpu", "imgui"]
 license = "MIT OR Apache-2.0"
+resolver = "2"
 
 exclude = [
 	".gitignore",
@@ -59,7 +60,7 @@ bytemuck = "1"
 imgui = "0.7"
 log = "0.4"
 smallvec = "1"
-wgpu = "0.9"
+wgpu = { version = "0.10", features = ["spirv"] }
 
 # deps for simple_api_unstable
 imgui-winit-support = { version = "0.7", optional = true }

--- a/examples/custom_textures.rs
+++ b/examples/custom_textures.rs
@@ -17,7 +17,7 @@ fn main() {
     // Set up window and GPU
     let event_loop = EventLoop::new();
 
-    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
     let (window, size, surface) = {
         let version = env!("CARGO_PKG_VERSION");
@@ -54,15 +54,15 @@ fn main() {
     .unwrap();
 
     // Set up swap chain
-    let sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+    let surface_desc = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         width: size.width as u32,
         height: size.height as u32,
         present_mode: wgpu::PresentMode::Mailbox,
     };
 
-    let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
+    surface.configure(&device, &surface_desc);
 
     // Set up dear imgui
     let mut imgui = imgui::Context::create();
@@ -96,7 +96,7 @@ fn main() {
         a: 1.0,
     };
     let renderer_config = RendererConfig {
-        texture_format: sc_desc.format,
+        texture_format: surface_desc.format,
         ..Default::default()
     };
 
@@ -143,15 +143,15 @@ fn main() {
             } => {
                 let size = window.inner_size();
 
-                let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+                let surface_desc = wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     width: size.width as u32,
                     height: size.height as u32,
                     present_mode: wgpu::PresentMode::Mailbox,
                 };
 
-                swap_chain = device.create_swap_chain(&surface, &sc_desc);
+                surface.configure(&device, &surface_desc);
             }
             Event::WindowEvent {
                 event:
@@ -180,7 +180,7 @@ fn main() {
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
 
-                let frame = match swap_chain.get_current_frame() {
+                let frame = match surface.get_current_frame() {
                     Ok(frame) => frame,
                     Err(e) => {
                         eprintln!("dropped frame: {:?}", e);
@@ -212,10 +212,14 @@ fn main() {
                     platform.prepare_render(&ui, &window);
                 }
 
+                let view = frame
+                    .output
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: None,
                     color_attachments: &[wgpu::RenderPassColorAttachment {
-                        view: &frame.output.view,
+                        view: &view,
                         resolve_target: None,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(clear_color),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub struct TextureConfig<'a> {
     /// The format of the texture, if not set uses the format from the renderer.
     pub format: Option<TextureFormat>,
     /// The usage of the texture.
-    pub usage: TextureUsage,
+    pub usage: TextureUsages,
     /// The mip level of the texture.
     pub mip_level_count: u32,
     /// The sample count of the texture.
@@ -77,7 +77,7 @@ impl<'a> Default for TextureConfig<'a> {
             },
             label: None,
             format: None,
-            usage: TextureUsage::SAMPLED | TextureUsage::COPY_DST,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
             mip_level_count: 1,
             sample_count: 1,
             dimension: TextureDimension::D2,
@@ -177,6 +177,7 @@ impl Texture {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: Origin3d { x: 0, y: 0, z: 0 },
+                aspect: TextureAspect::All,
             },
             // source bitmap data
             data,
@@ -319,7 +320,7 @@ impl Renderer {
         let uniform_buffer = device.create_buffer(&BufferDescriptor {
             label: Some("imgui-wgpu uniform buffer"),
             size,
-            usage: BufferUsage::UNIFORM | BufferUsage::COPY_DST,
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
             mapped_at_creation: false,
         });
 
@@ -328,7 +329,7 @@ impl Renderer {
             label: None,
             entries: &[BindGroupLayoutEntry {
                 binding: 0,
-                visibility: wgpu::ShaderStage::VERTEX,
+                visibility: wgpu::ShaderStages::VERTEX,
                 ty: BindingType::Buffer {
                     ty: BufferBindingType::Uniform,
                     has_dynamic_offset: false,
@@ -354,7 +355,7 @@ impl Renderer {
             entries: &[
                 BindGroupLayoutEntry {
                     binding: 0,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: BindingType::Texture {
                         multisampled: false,
                         sample_type: TextureSampleType::Float { filterable: true },
@@ -364,7 +365,7 @@ impl Renderer {
                 },
                 BindGroupLayoutEntry {
                     binding: 1,
-                    visibility: wgpu::ShaderStage::FRAGMENT,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
                     ty: BindingType::Sampler {
                         comparison: false,
                         filtering: true,
@@ -391,7 +392,7 @@ impl Renderer {
                 entry_point: "main",
                 buffers: &[VertexBufferLayout {
                     array_stride: size_of::<DrawVert>() as BufferAddress,
-                    step_mode: InputStepMode::Vertex,
+                    step_mode: VertexStepMode::Vertex,
                     attributes: &vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Unorm8x4],
                 }],
             },
@@ -432,7 +433,7 @@ impl Renderer {
                             operation: BlendOperation::Add,
                         },
                     }),
-                    write_mask: ColorWrite::ALL,
+                    write_mask: ColorWrites::ALL,
                 }],
             }),
         });
@@ -596,7 +597,7 @@ impl Renderer {
         device.create_buffer_init(&BufferInitDescriptor {
             label: Some("imgui-wgpu vertex buffer"),
             contents: data,
-            usage: BufferUsage::VERTEX,
+            usage: BufferUsages::VERTEX,
         })
     }
 
@@ -607,7 +608,7 @@ impl Renderer {
         device.create_buffer_init(&BufferInitDescriptor {
             label: Some("imgui-wgpu index buffer"),
             contents: data,
-            usage: BufferUsage::INDEX,
+            usage: BufferUsages::INDEX,
         })
     }
 

--- a/src/simple_api.rs
+++ b/src/simple_api.rs
@@ -84,7 +84,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
     // Set up window and GPU
     let event_loop = EventLoop::new();
 
-    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+    let instance = wgpu::Instance::new(wgpu::Backends::PRIMARY);
 
     let (window, size, surface) = {
         let window = Window::new(&event_loop).unwrap();
@@ -112,16 +112,15 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
         block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None)).unwrap();
 
     // Set up swap chain
-    let sc_desc = wgpu::SwapChainDescriptor {
-        usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+    let surface_desc = wgpu::SurfaceConfiguration {
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
         format: wgpu::TextureFormat::Bgra8UnormSrgb,
         width: size.width as u32,
         height: size.height as u32,
-        // limits refresh rate to the monitor's refresh rate, not wasting power spinning very quickly
         present_mode: wgpu::PresentMode::Fifo,
     };
 
-    let mut swap_chain = device.create_swap_chain(&surface, &sc_desc);
+    surface.configure(&device, &surface_desc);
 
     // Set up dear imgui
     let mut imgui = imgui::Context::create();
@@ -149,7 +148,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
     // Set up dear imgui wgpu renderer
     //
     let renderer_config = RendererConfig {
-        texture_format: sc_desc.format,
+        texture_format: surface_desc.format,
         ..Default::default()
     };
 
@@ -170,15 +169,15 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
             } => {
                 let size = window.inner_size();
 
-                let sc_desc = wgpu::SwapChainDescriptor {
-                    usage: wgpu::TextureUsage::RENDER_ATTACHMENT,
+                let surface_desc = wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,
                     width: size.width as u32,
                     height: size.height as u32,
-                    present_mode: wgpu::PresentMode::Mailbox,
+                    present_mode: wgpu::PresentMode::Fifo,
                 };
 
-                swap_chain = device.create_swap_chain(&surface, &sc_desc);
+                surface.configure(&device, &surface_desc);
 
                 (config.on_resize)(&size, &mut state, hidpi_factor);
             }
@@ -208,7 +207,7 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
 
-                let frame = match swap_chain.get_current_frame() {
+                let frame = match surface.get_current_frame() {
                     Ok(frame) => frame,
                     Err(e) => {
                         eprintln!("dropped frame: {:?}", e);
@@ -230,10 +229,14 @@ pub fn run<YourState: 'static, UiFunction: 'static + Fn(&imgui::Ui, &mut YourSta
                     platform.prepare_render(&ui, &window);
                 }
 
+                let view = frame
+                    .output
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
                     label: None,
                     color_attachments: &[wgpu::RenderPassColorAttachment {
-                        view: &frame.output.view,
+                        view: &view,
                         resolve_target: None,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Clear(config.background_color),


### PR DESCRIPTION
This PR updates the library to be compatible with wgpu 0.10.

Everything compiles and all the demos run, except for the `cube.rs` demo. It seems to stall out in the `Example::render()` function when submitting the command buffer to the queue. I will need to investigate if this is due to a change in wgpu or just a bug in updating to the latest version.

Because of this unsolved issue this PR is marked as WIP.

Fixes #65