### PR TITLE
Add README note to set `resolver = "2"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,13 @@ cargo run --release --example hello_world
 Basic features are useable. Uses `wgpu-0.9` and `imgui-0.7` upstream. `winit-0.24` is used with the examples.
 
 Contributions are very welcome.
+
+# Troubleshooting
+
+## Cargo resolver
+
+Starting with [`wgpu` 0.10](https://github.com/gfx-rs/wgpu/blob/06316c1bac8b78ac04d762cfb1a886bd1d453b30/CHANGELOG.md#v010-2021-08-18), the [resolver version](https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions) needs to be set in your `Cargo.toml` to avoid build errors:
+
+```toml
+resolver = "2"
+```


### PR DESCRIPTION
This is required for the top-level user Cargo.toml since wgpu 0.10 to avoid build errors.

Notice is copied from the https://github.com/parasyte/pixels project.