### PR TITLE
Make examples support wgpu 0.11

### DIFF
--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -353,6 +353,7 @@ fn main() {
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,
         compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
     }))
     .unwrap();
 
@@ -481,7 +482,7 @@ fn main() {
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
 
-                let frame = match surface.get_current_frame() {
+                let frame = match surface.get_current_texture() {
                     Ok(frame) => frame,
                     Err(e) => {
                         eprintln!("dropped frame: {:?}", e);
@@ -494,7 +495,6 @@ fn main() {
                 let ui = imgui.frame();
 
                 let view = frame
-                    .output
                     .texture
                     .create_view(&wgpu::TextureViewDescriptor::default());
 
@@ -572,6 +572,7 @@ fn main() {
                 drop(rpass);
 
                 queue.submit(Some(encoder.finish()));
+                frame.present();
             }
             _ => (),
         }

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -40,6 +40,7 @@ fn main() {
     let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
         power_preference: wgpu::PowerPreference::HighPerformance,
         compatible_surface: Some(&surface),
+        force_fallback_adapter: false,
     }))
     .unwrap();
 
@@ -180,7 +181,7 @@ fn main() {
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
 
-                let frame = match surface.get_current_frame() {
+                let frame = match surface.get_current_texture() {
                     Ok(frame) => frame,
                     Err(e) => {
                         eprintln!("dropped frame: {:?}", e);
@@ -213,7 +214,6 @@ fn main() {
                 }
 
                 let view = frame
-                    .output
                     .texture
                     .create_view(&wgpu::TextureViewDescriptor::default());
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -236,6 +236,7 @@ fn main() {
                 drop(rpass);
 
                 queue.submit(Some(encoder.finish()));
+                frame.present();
             }
             _ => (),
         }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -200,7 +200,6 @@ fn main() {
                 }
 
                 let view = frame
-                    .output
                     .texture
                     .create_view(&wgpu::TextureViewDescriptor::default());
                 let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
@@ -224,7 +223,7 @@ fn main() {
 
                 queue.submit(Some(encoder.finish()));
 
-                frame.submit();
+                frame.present();
             }
             _ => (),
         }


### PR DESCRIPTION
After updating to wgpu 0.11, I checked 685c87696355c79d19d22a12378662bdf71dd8f9 to understand what needed to be changed in my codebases. However, I noticed two contradicting changes (`frame.present()` vs `frame.submit()`). It turns out that submit is a mistake. 

I modified all three examples to accommodate the new changes to make them all compile on wgpu 0.11