### PR TITLE
Fix typo in README quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For usage, please have a look at the [example](examples/hello-world.rs).
 
 Run the example with
 ```
-cargo run --release --example hello_world
+cargo run --release --example hello-world
 ```
 
 # Status


### PR DESCRIPTION


<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

Not applicable, this is a documentation fix.
I am not seeking credit for this, it is a very minor fix.

## Description

New users copy-pasting from the README will encounter the following error:

```
$ cargo run --release --example hello_world
error: no example target named `hello_world`
	Did you mean `hello-world`?
```

This is a fix for the typo.

## Related Issues

None.