### PR TITLE
Set correct fb_size after window resize

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -514,6 +514,7 @@ impl Renderer {
             || (render_data.last_pos[0] - draw_data.display_pos[0]).abs() > std::f32::EPSILON
             || (render_data.last_pos[1] - draw_data.display_pos[1]).abs() > std::f32::EPSILON
         {
+            render_data.fb_size = [fb_width, fb_height];
             render_data.last_size = draw_data.display_size;
             render_data.last_pos = draw_data.display_pos;
 


### PR DESCRIPTION
## Description

In `Renderer::prepare(...)`, `render_data.fb_size` was never updated upon resize, although it's still passed as an argument to `Renderer::render_draw_list(...)`. This was resulting in the imgui windows not rendering properly outside of the original frame buffer size.

## Related Issues

Fixes issue #81