### PR TITLE
Make `Texture` take `Arc<T>` instead of `T`  to avoid being forced to move into the texture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - [Diffs](#diffs)
 
 ## Unreleased
+- Make `Texture::from_raw_parts` take `Arc<T>` instead of `T` to avoid being forced to move into the texture @BeastLe9enD
 
 ## v0.20.0
 


### PR DESCRIPTION
For example, if you have your own texture implementation, it can be painful being forced to move the `wgpu::Texture` into `Texture::from_raw_parts`. To workaround this, I changed the type form `wgpu::Texture` to `Arc<wgpu::Texture>` to allow cloning the texture, which allows still having the own texture implementation exist (same for `wgpu::TextureView` & `wgpu::BindGroup`). This is especially useful if you have a texture atlas that is used by ImGui but also used by the own renderer implementation. 

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

## Related Issues
