### PR TITLE
Change `BindGroup` inside `Texture::from_raw_parts` to `Option<BindGroup>` to allow bind group being created by imgui-wgpu-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - [Diffs](#diffs)
 
 ## Unreleased
+- Change `BindGroup` inside `Texture::from_raw_parts` to `Option<BindGroup>` to allow bind group being created by `imgui-wgpu-rs` @BeastLe9enD
 - Make `Texture::from_raw_parts` take `Arc<T>` instead of `T` to avoid being forced to move into the texture @BeastLe9enD
 
 - Moved from Rust Edition 2018 -> 2021 @Snowiiii


### PR DESCRIPTION
Hey, its me again,
I noticed that it can be really painful when you need to create the bind group inside `Texture::from_raw_parts` by yourself. My solution to this is changing the type of `bind_group` from `BindGroup` to `Option<BindGroup>` to allow passing the self-created bind group as a `Some` and using the `None` variant to create the bind group like the `Texture::new` function does.

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

## Related Issues
