### PR TITLE
Fix updating of WGPU texture size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ## Unreleased
 
 - Bump imgui version to 0.11.0. @benmkw
+- Fix issue with scissors due to wrong resizing logic. @dcvz
 
 ## v0.22.0
 

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -449,11 +449,9 @@ fn main() {
         };
         match event {
             Event::WindowEvent {
-                event: WindowEvent::Resized(_),
+                event: WindowEvent::Resized(size),
                 ..
             } => {
-                let size = window.inner_size();
-
                 let surface_desc = wgpu::SurfaceConfiguration {
                     usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -145,11 +145,9 @@ fn main() {
         };
         match event {
             Event::WindowEvent {
-                event: WindowEvent::Resized(_),
+                event: WindowEvent::Resized(size),
                 ..
             } => {
-                let size = window.inner_size();
-
                 let surface_desc = wgpu::SurfaceConfiguration {
                     usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -117,11 +117,9 @@ fn main() {
         };
         match event {
             Event::WindowEvent {
-                event: WindowEvent::Resized(_),
+                event: WindowEvent::Resized(size),
                 ..
             } => {
-                let size = window.inner_size();
-
                 let surface_desc = wgpu::SurfaceConfiguration {
                     usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                     format: wgpu::TextureFormat::Bgra8UnormSrgb,


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Fixes the resizing logic. Makes sure we create a texture that is of the proper size. The size the callback gets vs what `window.inner_size()` does not match up. ImGui however, uses the correct value and it causes a crash where a scissor bigger than the current texture is attempted.

## Related Issues

Perhaps #99 and #77 
