### PR TITLE
Pixelboys tm/issue77

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 ## Unreleased
 
+- Internal: Fixed Scissor-Rect to not span across Framebuffersize, by limiting to framebuffer width. @PixelboysTM
+
 ## v0.24.0
 
 Released 2023-08-02

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,8 +730,8 @@ impl Renderer {
                     let scissors = (
                         clip_rect[0].max(0.0).floor() as u32,
                         clip_rect[1].max(0.0).floor() as u32,
-                        (clip_rect[2] - clip_rect[0]).abs().ceil() as u32,
-                        (clip_rect[3] - clip_rect[1]).abs().ceil() as u32,
+                        (clip_rect[2].min(fb_size[0]) - clip_rect[0]).abs().ceil() as u32,
+                        (clip_rect[3].min(fb_size[1]) - clip_rect[1]).abs().ceil() as u32,
                     );
 
                     // XXX: Work-around for wgpu issue [1] by only issuing draw


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
Fixes wgpu tp panic because of to big scissor rects. Change limits scissor rect size to the soze of the framebuffer.

## Related Issues
