### PR TITLE
Update wgpu to 0.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ## Unreleased
 
 - Internal: Fixed Scissor-Rect to not span across Framebuffersize, by limiting to framebuffer width. @PixelboysTM
-- Bump wgpu version to 0.18. @calcoph
+- Bump wgpu version to 0.19. @mkrasnitski and @calcoph
 
 ## v0.24.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,20 @@ min = 0  # allow non-first increment
 
 [dependencies]
 bytemuck = "1"
-imgui = "0.11"
+imgui = "0.12"
 log = "0.4"
 smallvec = "1"
-wgpu = "0.18"
+wgpu = "0.19"
 
 [dev-dependencies]
 bytemuck = { version = "1.13", features = ["derive"] }
 cgmath = "0.18"
 env_logger = "0.10"
 image = { version = "0.24", default-features = false, features = ["png"] }
-imgui-winit-support = "0.11"
+imgui-winit-support = "0.12"
 pollster = "0.3"
 raw-window-handle = "0.5"
-winit = "0.27.5"
+winit = "0.29"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use wgpu::{include_wgsl, util::DeviceExt, Extent3d};
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
     window::WindowBuilder,
@@ -449,145 +449,136 @@ fn main() {
             elwt.set_control_flow(ControlFlow::Poll);
         };
         match event {
-            Event::WindowEvent {
-                event: WindowEvent::Resized(size),
-                ..
-            } => {
-                let surface_desc = wgpu::SurfaceConfiguration {
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    width: size.width,
-                    height: size.height,
-                    present_mode: wgpu::PresentMode::Fifo,
-                    desired_maximum_frame_latency: 2,
-                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                    view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-                };
-
-                surface.configure(&device, &surface_desc);
-            }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Named(NamedKey::Escape),
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            }
-            | Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => {
-                elwt.exit();
-            }
-            Event::WindowEvent {
-                event: WindowEvent::RedrawRequested,
-                ..
-            } => {
-                let now = Instant::now();
-                imgui.io_mut().update_delta_time(now - last_frame);
-                last_frame = now;
-
-                let frame = match surface.get_current_texture() {
-                    Ok(frame) => frame,
-                    Err(e) => {
-                        eprintln!("dropped frame: {e:?}");
-                        return;
-                    }
-                };
-                platform
-                    .prepare_frame(imgui.io_mut(), &window)
-                    .expect("Failed to prepare frame");
-                let ui = imgui.frame();
-
-                let view = frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-
-                // Render example normally at background
-                example.update(ui.io().delta_time);
-                example.setup_camera(&queue, ui.io().display_size);
-                example.render(&view, &device, &queue);
-
-                // Store the new size of Image() or None to indicate that the window is collapsed.
-                let mut new_example_size: Option<[f32; 2]> = None;
-
-                ui.window("Cube")
-                    .size([512.0, 512.0], Condition::FirstUseEver)
-                    .build(|| {
-                        new_example_size = Some(ui.content_region_avail());
-                        imgui::Image::new(example_texture_id, new_example_size.unwrap()).build(ui);
-                    });
-
-                if let Some(size) = new_example_size {
-                    // Resize render target, which is optional
-                    if size != example_size && size[0] >= 1.0 && size[1] >= 1.0 {
-                        example_size = size;
-                        let scale = &ui.io().display_framebuffer_scale;
-                        let texture_config = TextureConfig {
-                            size: Extent3d {
-                                width: (example_size[0] * scale[0]) as u32,
-                                height: (example_size[1] * scale[1]) as u32,
-                                ..Default::default()
-                            },
-                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
-                                | wgpu::TextureUsages::TEXTURE_BINDING,
-                            ..Default::default()
-                        };
-                        renderer.textures.replace(
-                            example_texture_id,
-                            Texture::new(&device, &renderer, texture_config),
-                        );
-                    }
-
-                    // Only render example to example_texture if thw window is not collapsed
-                    example.setup_camera(&queue, size);
-                    example.render(
-                        renderer.textures.get(example_texture_id).unwrap().view(),
-                        &device,
-                        &queue,
-                    );
-                }
-
-                let mut encoder: wgpu::CommandEncoder =
-                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-                if last_cursor != Some(ui.mouse_cursor()) {
-                    last_cursor = Some(ui.mouse_cursor());
-                    platform.prepare_render(ui, &window);
-                }
-
-                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: None,
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Load, // Do not clear
-                            // load: wgpu::LoadOp::Clear(clear_color),
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                });
-
-                renderer
-                    .render(imgui.render(), &queue, &device, &mut rpass)
-                    .expect("Rendering failed");
-
-                drop(rpass);
-
-                queue.submit(Some(encoder.finish()));
-                frame.present();
-            }
             Event::AboutToWait => window.request_redraw(),
+            Event::WindowEvent { ref event, .. } => {
+                match event {
+                    WindowEvent::Resized(size) => {
+                        let surface_desc = wgpu::SurfaceConfiguration {
+                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                            width: size.width,
+                            height: size.height,
+                            present_mode: wgpu::PresentMode::Fifo,
+                            desired_maximum_frame_latency: 2,
+                            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                            view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                        };
+
+                        surface.configure(&device, &surface_desc);
+                    }
+                    WindowEvent::CloseRequested => elwt.exit(),
+                    WindowEvent::KeyboardInput { event, .. } => {
+                        if let Key::Named(NamedKey::Escape) = event.logical_key {
+                            if event.state.is_pressed() {
+                                elwt.exit();
+                            }
+                        }
+                    }
+                    WindowEvent::RedrawRequested => {
+                        let now = Instant::now();
+                        imgui.io_mut().update_delta_time(now - last_frame);
+                        last_frame = now;
+
+                        let frame = match surface.get_current_texture() {
+                            Ok(frame) => frame,
+                            Err(e) => {
+                                eprintln!("dropped frame: {e:?}");
+                                return;
+                            }
+                        };
+                        platform
+                            .prepare_frame(imgui.io_mut(), &window)
+                            .expect("Failed to prepare frame");
+                        let ui = imgui.frame();
+
+                        let view = frame
+                            .texture
+                            .create_view(&wgpu::TextureViewDescriptor::default());
+
+                        // Render example normally at background
+                        example.update(ui.io().delta_time);
+                        example.setup_camera(&queue, ui.io().display_size);
+                        example.render(&view, &device, &queue);
+
+                        // Store the new size of Image() or None to indicate that the window is collapsed.
+                        let mut new_example_size: Option<[f32; 2]> = None;
+
+                        ui.window("Cube")
+                            .size([512.0, 512.0], Condition::FirstUseEver)
+                            .build(|| {
+                                new_example_size = Some(ui.content_region_avail());
+                                imgui::Image::new(example_texture_id, new_example_size.unwrap())
+                                    .build(ui);
+                            });
+
+                        if let Some(size) = new_example_size {
+                            // Resize render target, which is optional
+                            if size != example_size && size[0] >= 1.0 && size[1] >= 1.0 {
+                                example_size = size;
+                                let scale = &ui.io().display_framebuffer_scale;
+                                let texture_config = TextureConfig {
+                                    size: Extent3d {
+                                        width: (example_size[0] * scale[0]) as u32,
+                                        height: (example_size[1] * scale[1]) as u32,
+                                        ..Default::default()
+                                    },
+                                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                                        | wgpu::TextureUsages::TEXTURE_BINDING,
+                                    ..Default::default()
+                                };
+                                renderer.textures.replace(
+                                    example_texture_id,
+                                    Texture::new(&device, &renderer, texture_config),
+                                );
+                            }
+
+                            // Only render example to example_texture if thw window is not collapsed
+                            example.setup_camera(&queue, size);
+                            example.render(
+                                renderer.textures.get(example_texture_id).unwrap().view(),
+                                &device,
+                                &queue,
+                            );
+                        }
+
+                        let mut encoder: wgpu::CommandEncoder =
+                            device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                                label: None,
+                            });
+
+                        if last_cursor != Some(ui.mouse_cursor()) {
+                            last_cursor = Some(ui.mouse_cursor());
+                            platform.prepare_render(ui, &window);
+                        }
+
+                        let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                            label: None,
+                            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                                view: &view,
+                                resolve_target: None,
+                                ops: wgpu::Operations {
+                                    load: wgpu::LoadOp::Load, // Do not clear
+                                    // load: wgpu::LoadOp::Clear(clear_color),
+                                    store: wgpu::StoreOp::Store,
+                                },
+                            })],
+                            depth_stencil_attachment: None,
+                            timestamp_writes: None,
+                            occlusion_query_set: None,
+                        });
+
+                        renderer
+                            .render(imgui.render(), &queue, &device, &mut rpass)
+                            .expect("Rendering failed");
+
+                        drop(rpass);
+
+                        queue.submit(Some(encoder.finish()));
+                        frame.present();
+                    }
+                    _ => {}
+                }
+            }
             _ => {}
         }
 

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -7,7 +7,7 @@ use pollster::block_on;
 use std::time::Instant;
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, KeyEvent, WindowEvent},
+    event::{Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
     window::WindowBuilder,
@@ -115,126 +115,112 @@ fn main() {
             elwt.set_control_flow(ControlFlow::Poll);
         };
         match event {
-            Event::WindowEvent {
-                event: WindowEvent::Resized(size),
-                ..
-            } => {
-                let surface_desc = wgpu::SurfaceConfiguration {
-                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                    width: size.width,
-                    height: size.height,
-                    present_mode: wgpu::PresentMode::Fifo,
-                    desired_maximum_frame_latency: 2,
-                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                    view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-                };
-
-                surface.configure(&device, &surface_desc);
-            }
-            Event::WindowEvent {
-                event:
-                    WindowEvent::KeyboardInput {
-                        event:
-                            KeyEvent {
-                                logical_key: Key::Named(NamedKey::Escape),
-                                state: ElementState::Pressed,
-                                ..
-                            },
-                        ..
-                    },
-                ..
-            }
-            | Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
-            } => {
-                elwt.exit();
-            }
-            Event::WindowEvent {
-                event: WindowEvent::RedrawRequested,
-                ..
-            } => {
-                let delta_s = last_frame.elapsed();
-                let now = Instant::now();
-                imgui.io_mut().update_delta_time(now - last_frame);
-                last_frame = now;
-
-                let frame = match surface.get_current_texture() {
-                    Ok(frame) => frame,
-                    Err(e) => {
-                        eprintln!("dropped frame: {e:?}");
-                        return;
-                    }
-                };
-                platform
-                    .prepare_frame(imgui.io_mut(), &window)
-                    .expect("Failed to prepare frame");
-                let ui = imgui.frame();
-
-                {
-                    let window = ui.window("Hello world");
-                    window
-                        .size([300.0, 100.0], Condition::FirstUseEver)
-                        .build(|| {
-                            ui.text("Hello world!");
-                            ui.text("This...is...imgui-rs on WGPU!");
-                            ui.separator();
-                            let mouse_pos = ui.io().mouse_pos;
-                            ui.text(format!(
-                                "Mouse Position: ({:.1},{:.1})",
-                                mouse_pos[0], mouse_pos[1]
-                            ));
-                        });
-
-                    let window = ui.window("Hello too");
-                    window
-                        .size([400.0, 200.0], Condition::FirstUseEver)
-                        .position([400.0, 200.0], Condition::FirstUseEver)
-                        .build(|| {
-                            ui.text(format!("Frametime: {delta_s:?}"));
-                        });
-
-                    ui.show_demo_window(&mut demo_open);
-                }
-
-                let mut encoder: wgpu::CommandEncoder =
-                    device.create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-                if last_cursor != Some(ui.mouse_cursor()) {
-                    last_cursor = Some(ui.mouse_cursor());
-                    platform.prepare_render(ui, &window);
-                }
-
-                let view = frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                    label: None,
-                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                        view: &view,
-                        resolve_target: None,
-                        ops: wgpu::Operations {
-                            load: wgpu::LoadOp::Clear(clear_color),
-                            store: wgpu::StoreOp::Store,
-                        },
-                    })],
-                    depth_stencil_attachment: None,
-                    timestamp_writes: None,
-                    occlusion_query_set: None,
-                });
-
-                renderer
-                    .render(imgui.render(), &queue, &device, &mut rpass)
-                    .expect("Rendering failed");
-
-                drop(rpass);
-
-                queue.submit(Some(encoder.finish()));
-
-                frame.present();
-            }
             Event::AboutToWait => window.request_redraw(),
+            Event::WindowEvent { ref event, .. } => match event {
+                WindowEvent::Resized(size) => {
+                    let surface_desc = wgpu::SurfaceConfiguration {
+                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                        format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                        width: size.width,
+                        height: size.height,
+                        present_mode: wgpu::PresentMode::Fifo,
+                        desired_maximum_frame_latency: 2,
+                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                        view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                    };
+
+                    surface.configure(&device, &surface_desc);
+                }
+                WindowEvent::CloseRequested => elwt.exit(),
+                WindowEvent::KeyboardInput { event, .. } => {
+                    if let Key::Named(NamedKey::Escape) = event.logical_key {
+                        if event.state.is_pressed() {
+                            elwt.exit();
+                        }
+                    }
+                }
+                WindowEvent::RedrawRequested => {
+                    let delta_s = last_frame.elapsed();
+                    let now = Instant::now();
+                    imgui.io_mut().update_delta_time(now - last_frame);
+                    last_frame = now;
+
+                    let frame = match surface.get_current_texture() {
+                        Ok(frame) => frame,
+                        Err(e) => {
+                            eprintln!("dropped frame: {e:?}");
+                            return;
+                        }
+                    };
+                    platform
+                        .prepare_frame(imgui.io_mut(), &window)
+                        .expect("Failed to prepare frame");
+                    let ui = imgui.frame();
+
+                    {
+                        let window = ui.window("Hello world");
+                        window
+                            .size([300.0, 100.0], Condition::FirstUseEver)
+                            .build(|| {
+                                ui.text("Hello world!");
+                                ui.text("This...is...imgui-rs on WGPU!");
+                                ui.separator();
+                                let mouse_pos = ui.io().mouse_pos;
+                                ui.text(format!(
+                                    "Mouse Position: ({:.1},{:.1})",
+                                    mouse_pos[0], mouse_pos[1]
+                                ));
+                            });
+
+                        let window = ui.window("Hello too");
+                        window
+                            .size([400.0, 200.0], Condition::FirstUseEver)
+                            .position([400.0, 200.0], Condition::FirstUseEver)
+                            .build(|| {
+                                ui.text(format!("Frametime: {delta_s:?}"));
+                            });
+
+                        ui.show_demo_window(&mut demo_open);
+                    }
+
+                    let mut encoder: wgpu::CommandEncoder = device
+                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                    if last_cursor != Some(ui.mouse_cursor()) {
+                        last_cursor = Some(ui.mouse_cursor());
+                        platform.prepare_render(ui, &window);
+                    }
+
+                    let view = frame
+                        .texture
+                        .create_view(&wgpu::TextureViewDescriptor::default());
+                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            resolve_target: None,
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(clear_color),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+
+                    renderer
+                        .render(imgui.render(), &queue, &device, &mut rpass)
+                        .expect("Rendering failed");
+
+                    drop(rpass);
+
+                    queue.submit(Some(encoder.finish()));
+
+                    frame.present();
+                }
+                _ => {}
+            },
             _ => {}
         }
 


### PR DESCRIPTION
Supersedes #105 by incorporating #104. The first commit is the actual dependency bump, while the second commit is a simple refactor of the event loop body in the examples to unify the `Event::WindowEvent` match arms, with no other changes. I separated the two for the sake of easier review.