### PR TITLE
wgpu 0.20, imgui 0.12, winit 0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 and this project adheres to cargo's version of [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Per Keep a Changelog there are 6 main categories of changes:
+
 - Added
 - Changed
 - Deprecated
@@ -37,7 +38,9 @@ Per Keep a Changelog there are 6 main categories of changes:
 ## Unreleased
 
 - Internal: Fixed Scissor-Rect to not span across Framebuffersize, by limiting to framebuffer width. @PixelboysTM
-- Bump wgpu version to 0.19. @sarchar (changes based on @calcoph pull request)
+- Bump wgpu version to 0.20. @sarchar (0.19), @benmkw (0.20)
+- Bump imgui version to 0.12.0. @benmkw
+- Bump winit version to 0.29.3. @benmkw
 
 ## v0.24.0
 
@@ -54,6 +57,7 @@ Released 2023-08-02
 ## v0.22.0
 
 Released 2023-02-10
+
 - Change `BindGroup` inside `Texture::from_raw_parts` to `Option<BindGroup>` to allow bind group being created by `imgui-wgpu-rs` @BeastLe9enD
 - Make `Texture::from_raw_parts` take `Arc<T>` instead of `T` to avoid being forced to move into the texture @BeastLe9enD
 - Moved from Rust Edition 2018 -> 2021 @Snowiiii
@@ -62,6 +66,7 @@ Released 2023-02-10
 ## v0.21.0
 
 Released 2022-12-17
+
 - Bump imgui version to 0.9.0. Fix examples to match. @aholtzma-am
 
 ## v0.20.0
@@ -69,10 +74,12 @@ Released 2022-12-17
 Released 2022-07-11
 
 ### Updated
+
 - updated `wgpu` to 0.13 @Davidster
 - Internal: Use Fifo present mode in examples @Davidster
 
 ### Fixed
+
 - Fix issues with resizing due to the framebuffer size not being updated. @druks-232cc
 
 ## v0.19.0
@@ -80,14 +87,17 @@ Released 2022-07-11
 Released 2021-12-30
 
 ### Changed
+
 - Split up render into two internal functions, `prepare` and `split_render`.
 - Add `SamplerDesc` to TextureConfig
 
 ### Updated
+
 - updated wgpu dependency to `0.12`
 
 ### Removed
-- unreleased `simple-api` and moved to https://github.com/benmkw/imgui-wgpu-simple-api
+
+- unreleased `simple-api` and moved to <https://github.com/benmkw/imgui-wgpu-simple-api>
 
 ## v0.18.0
 
@@ -98,6 +108,7 @@ Released 2021-10-08
 Released 2021-10-08
 
 #### Updated
+
 - updated wgpu dependency to `>=0.10,<0.12`
 
 ## v0.17.1
@@ -105,9 +116,11 @@ Released 2021-10-08
 Released 2021-09-22
 
 #### Updated
+
 - updated imgui dependency to `>=0.1,<0.9`
 
 #### Removed
+
 - unstable simple-api is now it's own, unpublished, crate.
 
 ## v0.17.0
@@ -115,12 +128,15 @@ Released 2021-09-22
 Released 2021-09-04
 
 #### Changed
+
 - Internal: translate shaders from SPIR-V to WGSL
 
 #### Updated
+
 - updated `wgpu` to 0.10
 
 #### Fixed
+
 - Internal: fix all warnings from static analysis (clippy).
 - Internal: Do not render draw commands that fall outside the framebuffer
 - Internal: Avoid wgpu logic error by not rendering empty clip rects
@@ -130,18 +146,22 @@ Released 2021-09-04
 Released 2021-07-14
 
 #### Added
+
 - Internal: Vastly improved CI and release process.
 - Internal: PR and Issue Templates
 
 #### Changed
+
 - Examples: Use `env_logger` instead of `wgpu-subscriber`
 - Examples: Use `pollster` as block_on provider instead of `futures`
 
 #### Fixed
+
 - Rendering to multi-sampled images no longer errors.
 - Examples: Simple API examples now properly depend on that feature existing.
 
 #### Updated
+
 - updated `wgpu` to 0.9
 
 ## v0.15.1
@@ -149,9 +169,11 @@ Released 2021-07-14
 Released 2021-05-08
 
 #### Fixed
+
 - removed hack due to wgpu bug
 
 #### Updated
+
 - updated `wgpu` to 0.8.1
 
 ## v0.15.0
@@ -159,6 +181,7 @@ Released 2021-05-08
 Released 2021-05-08
 
 #### Updated
+
 - updated `wgpu` to 0.8
 
 ## v0.14.0
@@ -166,6 +189,7 @@ Released 2021-05-08
 Released 2021-02-12
 
 #### Updated
+
 - updated `imgui` to 0.7
 
 ## v0.13.1
@@ -173,6 +197,7 @@ Released 2021-02-12
 Released 2021-02-01
 
 #### Fixed
+
 - Readme
 
 ## v0.13.0
@@ -180,10 +205,12 @@ Released 2021-02-01
 Released 2021-02-01
 
 #### Added
+
 - Add experimental simple api behind feature `simple_api_unstable`
 - Implemented `std::error::Error` for `RendererError`
 
 #### Updated
+
 - updated to `wgpu` 0.7
 - support `winit` 0.24 as well as 0.23
 
@@ -192,15 +219,18 @@ Released 2021-02-01
 Released 2020-11-21
 
 #### Added
+
 - A changelog!
 - Shaders are now SRGB aware. Choose `RendererConfig::new()` to get shaders outputting in linear color
   and `RendererConfig::new_srgb()` for shaders outputting SRGB.
 
 #### Updated
+
 - `imgui` to `0.6`.
 - `winit` to `0.23`
 
 #### Removed
+
 - GLSL shaders and `glsl-to-spirv`. If you want a custom shader, provide custom spirv to `RendererConfig::with_shaders()`, however you must generate it.
 
 ## Diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 ## Unreleased
 
 - Internal: Fixed Scissor-Rect to not span across Framebuffersize, by limiting to framebuffer width. @PixelboysTM
-- Bump wgpu version to 0.18. @calcoph
+- Bump wgpu version to 0.19. @sarchar (changes based on @calcoph pull request)
 
 ## v0.24.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "imgui-wgpu"
 version = "0.24.0"
-authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Connor Fitzgerald <connorwadefitzgerald@gmail.com>", "Steven Wittens <steven@acko.net>"]
+authors = [
+	"Noah Hüsser <yatekii@yatekii.ch>",
+	"Connor Fitzgerald <connorwadefitzgerald@gmail.com>",
+	"Steven Wittens <steven@acko.net>",
+]
 edition = "2021"
 description = "A wgpu render backend for imgui-rs."
 documentation = "https://docs.rs/imgui-wgpu/"
@@ -12,11 +16,7 @@ categories = ["gui", "graphics", "rendering", "rendering::graphics-api"]
 keywords = ["gui", "graphics", "wgpu", "imgui"]
 license = "MIT OR Apache-2.0"
 
-exclude = [
-	".gitignore",
-	".github",
-	"resources",
-]
+exclude = [".gitignore", ".github", "resources"]
 
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"
@@ -34,29 +34,29 @@ replace = "## Unreleased\n\n## v{{version}}\n\nReleased {{date}}"
 file = "CHANGELOG.md"
 search = "\\[Unreleased\\]\\(https://github.com/Yatekii/imgui-wgpu-rs/compare/v([a-z0-9.-]+)\\.\\.\\.HEAD\\)"
 replace = "[Unreleased](https://github.com/Yatekii/imgui-wgpu-rs/compare/v{{version}}...HEAD)\n- [v{{version}}](https://github.com/Yatekii/imgui-wgpu-rs/compare/v$1...v{{version}})"
-min = 0  # allow first increment
+min = 0                                                                                                                                                                               # allow first increment
 [[package.metadata.release.pre-release-replacements]]
 file = "CHANGELOG.md"
 search = "<!-- Begin Diffs -->"
 replace = "- [Unreleased](https://github.com/Yatekii/imgui-wgpu-rs/compare/v{{version}}...HEAD)"
-min = 0  # allow non-first increment
+min = 0                                                                                          # allow non-first increment
 
 [dependencies]
 bytemuck = "1"
-imgui = { git = "https://github.com/imgui-rs/imgui-rs" }
+imgui = "0.12"
 log = "0.4"
 smallvec = "1"
-wgpu = "0.19"
+wgpu = "0.20"
 
 [dev-dependencies]
 bytemuck = { version = "1.13", features = ["derive"] }
 cgmath = "0.18"
-env_logger = "0.10"
-image = { version = "0.24", default-features = false, features = ["png"] }
-imgui-winit-support = { git = "https://github.com/imgui-rs/imgui-rs" }
+env_logger = "0.11.3"
+image = { version = "0.25.1", default-features = false, features = ["png"] }
+imgui-winit-support = "0.12"
 pollster = "0.3"
-raw-window-handle = "0.5"
-winit = "0.29"
+raw-window-handle = "0.6.1"
+winit = "0.29.3"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,20 +43,20 @@ min = 0  # allow non-first increment
 
 [dependencies]
 bytemuck = "1"
-imgui = "0.11"
+imgui = { git = "https://github.com/imgui-rs/imgui-rs" }
 log = "0.4"
 smallvec = "1"
-wgpu = "0.18"
+wgpu = "0.19"
 
 [dev-dependencies]
 bytemuck = { version = "1.13", features = ["derive"] }
 cgmath = "0.18"
 env_logger = "0.10"
 image = { version = "0.24", default-features = false, features = ["png"] }
-imgui-winit-support = "0.11"
+imgui-winit-support = { git = "https://github.com/imgui-rs/imgui-rs" }
 pollster = "0.3"
 raw-window-handle = "0.5"
-winit = "0.27.5"
+winit = "0.29"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use wgpu::{include_wgsl, util::DeviceExt, Extent3d};
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, WindowEvent, KeyEvent},
+    event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
     window::Window,
@@ -255,11 +255,14 @@ impl Example {
                 module: &shader,
                 entry_point: "vs_main",
                 buffers: &vertex_buffers,
+                compilation_options: Default::default(),
             },
+
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: "fs_main",
                 targets: &[Some(config.format.into())],
+                compilation_options: Default::default(),
             }),
             primitive: wgpu::PrimitiveState {
                 cull_mode: Some(wgpu::Face::Back),
@@ -347,7 +350,6 @@ fn main() {
         let _ = window.request_inner_size(LogicalSize::new(1280.0, 720.0));
         window.set_title(&format!("imgui-wgpu {version}"));
         let size = window.inner_size();
-
 
         (window, size)
     };
@@ -446,9 +448,6 @@ fn main() {
 
     // Event loop
     let _ = event_loop.run(|event, elwt| {
-        if cfg!(feature = "metal-auto-capture") {
-            elwt.exit();
-        };
         match event {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 use wgpu::{include_wgsl, util::DeviceExt, Extent3d};
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event::{ElementState, Event, WindowEvent, KeyEvent},
     event_loop::{ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
     window::Window,
 };
 
@@ -311,8 +312,8 @@ impl Example {
                     },
                 })],
                 depth_stencil_attachment: None,
-                timestamp_writes: None,
                 occlusion_query_set: None,
+                timestamp_writes: None,
             });
             rpass.push_debug_group("Prepare data for draw.");
             rpass.set_pipeline(&self.pipeline);
@@ -332,28 +333,26 @@ fn main() {
     env_logger::init();
 
     // Set up window and GPU
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().expect("Error creating event loop");
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::PRIMARY,
         ..Default::default()
     });
 
-    let (window, size, surface) = {
+    let (window, size) = {
         let version = env!("CARGO_PKG_VERSION");
 
         let window = Window::new(&event_loop).unwrap();
-        window.set_inner_size(LogicalSize {
-            width: 1280.0,
-            height: 720.0,
-        });
+        let _ = window.request_inner_size(LogicalSize::new(1280.0, 720.0));
         window.set_title(&format!("imgui-wgpu {version}"));
         let size = window.inner_size();
 
-        let surface = unsafe { instance.create_surface(&window) }.unwrap();
 
-        (window, size, surface)
+        (window, size)
     };
+
+    let surface = instance.create_surface(&window).unwrap();
 
     let hidpi_factor = window.scale_factor();
 
@@ -376,6 +375,7 @@ fn main() {
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: wgpu::CompositeAlphaMode::Auto,
         view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        desired_maximum_frame_latency: 0,
     };
 
     surface.configure(&device, &surface_desc);
@@ -442,12 +442,12 @@ fn main() {
     let texture = Texture::new(&device, &renderer, texture_config);
     let example_texture_id = renderer.textures.insert(texture);
 
+    event_loop.set_control_flow(ControlFlow::Poll);
+
     // Event loop
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = if cfg!(feature = "metal-auto-capture") {
-            ControlFlow::Exit
-        } else {
-            ControlFlow::Poll
+    let _ = event_loop.run(|event, elwt| {
+        if cfg!(feature = "metal-auto-capture") {
+            elwt.exit();
         };
         match event {
             Event::WindowEvent {
@@ -462,6 +462,7 @@ fn main() {
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                    desired_maximum_frame_latency: 0,
                 };
 
                 surface.configure(&device, &surface_desc);
@@ -469,9 +470,9 @@ fn main() {
             Event::WindowEvent {
                 event:
                     WindowEvent::KeyboardInput {
-                        input:
-                            KeyboardInput {
-                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                        event:
+                            KeyEvent {
+                                logical_key: Key::Named(NamedKey::Escape),
                                 state: ElementState::Pressed,
                                 ..
                             },
@@ -483,10 +484,13 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                *control_flow = ControlFlow::Exit;
+                elwt.exit();
             }
-            Event::MainEventsCleared => window.request_redraw(),
-            Event::RedrawEventsCleared => {
+            Event::AboutToWait => window.request_redraw(),
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 let now = Instant::now();
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
@@ -572,8 +576,8 @@ fn main() {
                         },
                     })],
                     depth_stencil_attachment: None,
-                    timestamp_writes: None,
                     occlusion_query_set: None,
+                    timestamp_writes: None,
                 });
 
                 renderer

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 use wgpu::Extent3d;
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, WindowEvent, KeyEvent},
+    event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
     window::Window,
@@ -139,9 +139,6 @@ fn main() {
 
     // Event loop
     let _ = event_loop.run(|event, elwt| {
-        if cfg!(feature = "metal-auto-capture") {
-            elwt.exit();
-        };
         match event {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -6,8 +6,9 @@ use std::time::Instant;
 use wgpu::Extent3d;
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event::{ElementState, Event, WindowEvent, KeyEvent},
     event_loop::{ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
     window::Window,
 };
 
@@ -15,28 +16,25 @@ fn main() {
     env_logger::init();
 
     // Set up window and GPU
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().expect("Error creating event loop");
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::PRIMARY,
         ..Default::default()
     });
 
-    let (window, size, surface) = {
+    let (window, size) = {
         let version = env!("CARGO_PKG_VERSION");
 
         let window = Window::new(&event_loop).unwrap();
-        window.set_inner_size(LogicalSize {
-            width: 1280.0,
-            height: 720.0,
-        });
+        let _ = window.request_inner_size(LogicalSize::new(1280.0, 720.0));
         window.set_title(&format!("imgui-wgpu {version}"));
         let size = window.inner_size();
 
-        let surface = unsafe { instance.create_surface(&window) }.unwrap();
-
-        (window, size, surface)
+        (window, size)
     };
+
+    let surface = instance.create_surface(&window).unwrap();
 
     let hidpi_factor = window.scale_factor();
 
@@ -50,8 +48,8 @@ fn main() {
     let (device, queue) = block_on(adapter.request_device(
         &wgpu::DeviceDescriptor {
             label: None,
-            features: wgpu::Features::empty(),
-            limits: wgpu::Limits::default(),
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::default(),
         },
         None,
     ))
@@ -66,6 +64,7 @@ fn main() {
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: wgpu::CompositeAlphaMode::Auto,
         view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        desired_maximum_frame_latency: 0,
     };
 
     surface.configure(&device, &surface_desc);
@@ -136,12 +135,12 @@ fn main() {
 
     let mut last_cursor = None;
 
+    event_loop.set_control_flow(ControlFlow::Poll);
+
     // Event loop
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = if cfg!(feature = "metal-auto-capture") {
-            ControlFlow::Exit
-        } else {
-            ControlFlow::Poll
+    let _ = event_loop.run(|event, elwt| {
+        if cfg!(feature = "metal-auto-capture") {
+            elwt.exit();
         };
         match event {
             Event::WindowEvent {
@@ -156,6 +155,7 @@ fn main() {
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                    desired_maximum_frame_latency: 0,
                 };
 
                 surface.configure(&device, &surface_desc);
@@ -163,9 +163,9 @@ fn main() {
             Event::WindowEvent {
                 event:
                     WindowEvent::KeyboardInput {
-                        input:
-                            KeyboardInput {
-                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                        event:
+                            KeyEvent {
+                                logical_key: Key::Named(NamedKey::Escape),
                                 state: ElementState::Pressed,
                                 ..
                             },
@@ -177,12 +177,15 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                *control_flow = ControlFlow::Exit;
+                elwt.exit();
             }
-            Event::MainEventsCleared => {
+            Event::AboutToWait => {
                 window.request_redraw();
             }
-            Event::RedrawEventsCleared => {
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 let now = Instant::now();
                 imgui.io_mut().update_delta_time(now - last_frame);
                 last_frame = now;
@@ -233,8 +236,8 @@ fn main() {
                         },
                     })],
                     depth_stencil_attachment: None,
-                    timestamp_writes: None,
                     occlusion_query_set: None,
+                    timestamp_writes: None,
                 });
 
                 renderer

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -7,7 +7,7 @@ use pollster::block_on;
 use std::time::Instant;
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, WindowEvent, KeyEvent},
+    event::{ElementState, Event, KeyEvent, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
     window::Window,
@@ -111,9 +111,6 @@ fn main() {
 
     // Event loop
     let _ = event_loop.run(|event, elwt| {
-        if cfg!(feature = "metal-auto-capture") {
-            elwt.exit();
-        };
         match event {
             Event::WindowEvent {
                 event: WindowEvent::Resized(size),
@@ -135,7 +132,7 @@ fn main() {
             Event::WindowEvent {
                 event:
                     WindowEvent::KeyboardInput {
-                        event: 
+                        event:
                             KeyEvent {
                                 logical_key: Key::Named(NamedKey::Escape),
                                 state: ElementState::Pressed,

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -7,8 +7,9 @@ use pollster::block_on;
 use std::time::Instant;
 use winit::{
     dpi::LogicalSize,
-    event::{ElementState, Event, KeyboardInput, VirtualKeyCode, WindowEvent},
+    event::{ElementState, Event, WindowEvent, KeyEvent},
     event_loop::{ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
     window::Window,
 };
 
@@ -16,28 +17,25 @@ fn main() {
     env_logger::init();
 
     // Set up window and GPU
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().expect("Error creating event loop");
 
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::PRIMARY,
         ..Default::default()
     });
 
-    let (window, size, surface) = {
+    let (window, size) = {
         let version = env!("CARGO_PKG_VERSION");
 
         let window = Window::new(&event_loop).unwrap();
-        window.set_inner_size(LogicalSize {
-            width: 1280.0,
-            height: 720.0,
-        });
+        let _ = window.request_inner_size(LogicalSize::new(1280.0, 720.0));
         window.set_title(&format!("imgui-wgpu {version}"));
         let size = window.inner_size();
 
-        let surface = unsafe { instance.create_surface(&window) }.unwrap();
-
-        (window, size, surface)
+        (window, size)
     };
+
+    let surface = instance.create_surface(&window).unwrap();
 
     let hidpi_factor = window.scale_factor();
 
@@ -60,6 +58,7 @@ fn main() {
         present_mode: wgpu::PresentMode::Fifo,
         alpha_mode: wgpu::CompositeAlphaMode::Auto,
         view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        desired_maximum_frame_latency: 0,
     };
 
     surface.configure(&device, &surface_desc);
@@ -108,12 +107,12 @@ fn main() {
 
     let mut last_cursor = None;
 
+    event_loop.set_control_flow(ControlFlow::Poll);
+
     // Event loop
-    event_loop.run(move |event, _, control_flow| {
-        *control_flow = if cfg!(feature = "metal-auto-capture") {
-            ControlFlow::Exit
-        } else {
-            ControlFlow::Poll
+    let _ = event_loop.run(|event, elwt| {
+        if cfg!(feature = "metal-auto-capture") {
+            elwt.exit();
         };
         match event {
             Event::WindowEvent {
@@ -128,6 +127,7 @@ fn main() {
                     present_mode: wgpu::PresentMode::Fifo,
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                    desired_maximum_frame_latency: 0,
                 };
 
                 surface.configure(&device, &surface_desc);
@@ -135,9 +135,9 @@ fn main() {
             Event::WindowEvent {
                 event:
                     WindowEvent::KeyboardInput {
-                        input:
-                            KeyboardInput {
-                                virtual_keycode: Some(VirtualKeyCode::Escape),
+                        event: 
+                            KeyEvent {
+                                logical_key: Key::Named(NamedKey::Escape),
                                 state: ElementState::Pressed,
                                 ..
                             },
@@ -149,10 +149,13 @@ fn main() {
                 event: WindowEvent::CloseRequested,
                 ..
             } => {
-                *control_flow = ControlFlow::Exit;
+                elwt.exit();
             }
-            Event::MainEventsCleared => window.request_redraw(),
-            Event::RedrawEventsCleared => {
+            Event::AboutToWait => window.request_redraw(),
+            Event::WindowEvent {
+                event: WindowEvent::RedrawRequested,
+                ..
+            } => {
                 let delta_s = last_frame.elapsed();
                 let now = Instant::now();
                 imgui.io_mut().update_delta_time(now - last_frame);
@@ -218,8 +221,8 @@ fn main() {
                         },
                     })],
                     depth_stencil_attachment: None,
-                    timestamp_writes: None,
                     occlusion_query_set: None,
+                    timestamp_writes: None,
                 });
 
                 renderer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,6 +448,7 @@ impl Renderer {
                     step_mode: VertexStepMode::Vertex,
                     attributes: &vertex_attr_array![0 => Float32x2, 1 => Float32x2, 2 => Unorm8x4],
                 }],
+                compilation_options: Default::default(),
             },
             primitive: PrimitiveState {
                 topology: PrimitiveTopology::TriangleList,
@@ -488,6 +489,7 @@ impl Renderer {
                     }),
                     write_mask: ColorWrites::ALL,
                 })],
+                compilation_options: Default::default(),
             }),
             multiview: None,
         });


### PR DESCRIPTION
based on https://github.com/Yatekii/imgui-wgpu-rs/pull/107

imgui-rs released 0.12 which fixed some dependency issues 

I don't use imgui that often anymore but would still like to update https://github.com/benmkw/imnodes-rs just because some people use it from time to time and it will help to keep at least the basics working.

For others reading this I would recommend checking out egui if that may be an option.