### PR TITLE
Backend should respect idx and vtx offsets given by ImGui

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,8 +701,6 @@ impl Renderer {
         clip_scale: [f32; 2],
         (vertex_base, index_base): (i32, u32),
     ) -> RendererResult<()> {
-        let mut start = index_base;
-
         for cmd in draw_list.commands() {
             if let Elements { count, cmd_params } = cmd {
                 let clip_rect = [
@@ -721,6 +719,7 @@ impl Renderer {
                 rpass.set_bind_group(1, &tex.bind_group, &[]);
 
                 // Set scissors on the renderpass.
+                let start = index_base + cmd_params.idx_offset as u32;
                 let end = start + count as u32;
                 if clip_rect[0] < fb_size[0]
                     && clip_rect[1] < fb_size[1]
@@ -747,13 +746,12 @@ impl Renderer {
                         rpass.set_scissor_rect(scissors.0, scissors.1, scissors.2, scissors.3);
 
                         // Draw the current batch of vertices with the renderpass.
-                        rpass.draw_indexed(start..end, vertex_base, 0..1);
+                        rpass.draw_indexed(start..end, vertex_base + cmd_params.vtx_offset as i32, 0..1);
                     }
                 }
 
                 // Increment the index regardless of whether or not this batch
                 // of vertices was drawn.
-                start = end;
             }
         }
         Ok(())


### PR DESCRIPTION
This fixes background dimming with modal popups and (probably) the CTRL+Tab box

<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [ ] `cargo clippy` reports no issues
- [ ] `cargo doc` reports no issues
- [ ] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [ ] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [ ] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

## Related Issues
