### PR TITLE
Bump wgpu to 22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 
 - Internal: Fixed Scissor-Rect to not span across Framebuffersize, by limiting to framebuffer width. @PixelboysTM
 - Bump wgpu version to 0.19. @mkrasnitski and @calcoph
+- Bump wgpu version to 22.1. @aftix
 
 ## v0.24.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imgui-wgpu"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Noah Hüsser <yatekii@yatekii.ch>", "Connor Fitzgerald <connorwadefitzgerald@gmail.com>", "Steven Wittens <steven@acko.net>"]
 edition = "2021"
 description = "A wgpu render backend for imgui-rs."
@@ -46,17 +46,17 @@ bytemuck = "1"
 imgui = "0.12"
 log = "0.4"
 smallvec = "1"
-wgpu = "0.19"
+wgpu = "22.1"
 
 [dev-dependencies]
 bytemuck = { version = "1.13", features = ["derive"] }
 cgmath = "0.18"
 env_logger = "0.10"
 image = { version = "0.24", default-features = false, features = ["png"] }
-imgui-winit-support = "0.12"
+imgui-winit-support = "0.13"
 pollster = "0.3"
 raw-window-handle = "0.5"
-winit = "0.29"
+winit = "0.30"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/deny.toml
+++ b/deny.toml
@@ -11,6 +11,9 @@ allow = [
 [bans]
 multiple-versions = "deny"
 skip = [
+    { name = "syn", version = "2.0.82" },
+    { name = "bitflags", version = "1.3.2" },
+    { name = "hashbrown", version = "0.14.5" },
 ]
 skip-tree = [
     { name = "winit", version = "0.27.5" },

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -1,241 +1,354 @@
 use image::ImageFormat;
 use imgui::*;
 use imgui_wgpu::{Renderer, RendererConfig, Texture, TextureConfig};
+use imgui_winit_support::WinitPlatform;
 use pollster::block_on;
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 use wgpu::Extent3d;
 use winit::{
+    application::ApplicationHandler,
     dpi::LogicalSize,
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
-    window::WindowBuilder,
+    window::Window,
 };
+
+struct ImguiState {
+    context: imgui::Context,
+    platform: WinitPlatform,
+    renderer: Renderer,
+    clear_color: wgpu::Color,
+    width: u32,
+    height: u32,
+    checker_texture_id: TextureId,
+    last_frame: Instant,
+    last_cursor: Option<MouseCursor>,
+}
+
+struct AppWindow {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    window: Arc<Window>,
+    surface_desc: wgpu::SurfaceConfiguration,
+    surface: wgpu::Surface<'static>,
+    hidpi_factor: f64,
+    imgui: Option<ImguiState>,
+}
+
+#[derive(Default)]
+struct App {
+    window: Option<AppWindow>,
+}
+
+impl AppWindow {
+    fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            ..Default::default()
+        });
+
+        let window = {
+            let version = env!("CARGO_PKG_VERSION");
+
+            let size = LogicalSize::new(1280.0, 720.0);
+
+            let attributes = Window::default_attributes()
+                .with_inner_size(size)
+                .with_title(&format!("imgui-wgpu {version}"));
+            Arc::new(event_loop.create_window(attributes).unwrap())
+        };
+
+        let size = window.inner_size();
+        let hidpi_factor = window.scale_factor();
+        let surface = instance.create_surface(window.clone()).unwrap();
+
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .unwrap();
+
+        let (device, queue) =
+            block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None)).unwrap();
+
+        // Set up swap chain
+        let surface_desc = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            width: size.width,
+            height: size.height,
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        };
+
+        surface.configure(&device, &surface_desc);
+
+        let imgui = None;
+        Self {
+            device,
+            queue,
+            window,
+            surface_desc,
+            surface,
+            hidpi_factor,
+            imgui,
+        }
+    }
+
+    fn setup_imgui(&mut self) {
+        let mut context = imgui::Context::create();
+        let mut platform = imgui_winit_support::WinitPlatform::new(&mut context);
+        platform.attach_window(
+            context.io_mut(),
+            &self.window,
+            imgui_winit_support::HiDpiMode::Default,
+        );
+        context.set_ini_filename(None);
+
+        let font_size = (13.0 * self.hidpi_factor) as f32;
+        context.io_mut().font_global_scale = (1.0 / self.hidpi_factor) as f32;
+
+        context.fonts().add_font(&[FontSource::DefaultFontData {
+            config: Some(imgui::FontConfig {
+                oversample_h: 1,
+                pixel_snap_h: true,
+                size_pixels: font_size,
+                ..Default::default()
+            }),
+        }]);
+
+        //
+        // Set up dear imgui wgpu renderer
+        //
+        let clear_color = wgpu::Color {
+            r: 0.1,
+            g: 0.2,
+            b: 0.3,
+            a: 1.0,
+        };
+
+        let renderer_config = RendererConfig {
+            texture_format: self.surface_desc.format,
+            ..Default::default()
+        };
+
+        let mut renderer = Renderer::new(&mut context, &self.device, &self.queue, renderer_config);
+
+        let last_frame = Instant::now();
+        let last_cursor = None;
+
+        let checker_bytes = include_bytes!("../resources/checker.png");
+        let image = image::load_from_memory_with_format(checker_bytes, ImageFormat::Png)
+            .expect("invalid image");
+        let image = image.to_rgba8();
+        let (width, height) = image.dimensions();
+        let raw_data = image.into_raw();
+
+        let texture_config = TextureConfig {
+            size: Extent3d {
+                width,
+                height,
+                ..Default::default()
+            },
+            label: Some("checker texture"),
+            format: Some(wgpu::TextureFormat::Rgba8Unorm),
+            ..Default::default()
+        };
+
+        let texture = Texture::new(&self.device, &renderer, texture_config);
+
+        texture.write(&self.queue, &raw_data, width, height);
+        let checker_texture_id = renderer.textures.insert(texture);
+
+        self.imgui = Some(ImguiState {
+            context,
+            platform,
+            renderer,
+            clear_color,
+            width,
+            height,
+            checker_texture_id,
+            last_frame,
+            last_cursor,
+        })
+    }
+
+    fn new(event_loop: &ActiveEventLoop) -> Self {
+        let mut window = Self::setup_gpu(event_loop);
+        window.setup_imgui();
+        window
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.window = Some(AppWindow::new(event_loop));
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+
+        match &event {
+            WindowEvent::Resized(size) => {
+                window.surface_desc = wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    width: size.width,
+                    height: size.height,
+                    present_mode: wgpu::PresentMode::Fifo,
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                };
+
+                window
+                    .surface
+                    .configure(&window.device, &window.surface_desc);
+            }
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::KeyboardInput { event, .. } => {
+                if let Key::Named(NamedKey::Escape) = event.logical_key {
+                    if event.state.is_pressed() {
+                        event_loop.exit();
+                    }
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let now = Instant::now();
+                imgui
+                    .context
+                    .io_mut()
+                    .update_delta_time(now - imgui.last_frame);
+                imgui.last_frame = now;
+
+                let frame = match window.surface.get_current_texture() {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        eprintln!("dropped frame: {e:?}");
+                        return;
+                    }
+                };
+                imgui
+                    .platform
+                    .prepare_frame(imgui.context.io_mut(), &window.window)
+                    .expect("Failed to prepare frame");
+                let ui = imgui.context.frame();
+
+                {
+                    let size = [imgui.width as f32, imgui.height as f32];
+                    let window = ui.window("Hello world");
+                    window
+                        .size([400.0, 600.0], Condition::FirstUseEver)
+                        .build(|| {
+                            ui.text("Hello textures!");
+                            ui.text("Say hello to checker.png");
+                            Image::new(imgui.checker_texture_id, size).build(ui);
+                        });
+                }
+
+                let mut encoder: wgpu::CommandEncoder = window
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                if imgui.last_cursor != ui.mouse_cursor() {
+                    imgui.last_cursor = ui.mouse_cursor();
+                    imgui.platform.prepare_render(ui, &window.window);
+                }
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(imgui.clear_color),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                imgui
+                    .renderer
+                    .render(
+                        imgui.context.render(),
+                        &window.queue,
+                        &window.device,
+                        &mut rpass,
+                    )
+                    .expect("Rendering failed");
+
+                drop(rpass);
+
+                window.queue.submit(Some(encoder.finish()));
+                frame.present();
+            }
+            _ => (),
+        }
+
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::WindowEvent { window_id, event },
+        );
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: ()) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::UserEvent(event),
+        );
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::DeviceEvent { device_id, event },
+        );
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        window.window.request_redraw();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::AboutToWait,
+        );
+    }
+}
 
 fn main() {
     env_logger::init();
 
-    // Set up window and GPU
     let event_loop = EventLoop::new().unwrap();
-
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::PRIMARY,
-        ..Default::default()
-    });
-
-    let window = {
-        let version = env!("CARGO_PKG_VERSION");
-
-        let size = LogicalSize::new(1280.0, 720.0);
-        WindowBuilder::new()
-            .with_inner_size(size)
-            .with_title(&format!("imgui-wgpu {version}"))
-            .build(&event_loop)
-            .unwrap()
-    };
-    let size = window.inner_size();
-    let surface = instance.create_surface(&window).unwrap();
-
-    let hidpi_factor = window.scale_factor();
-
-    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        compatible_surface: Some(&surface),
-        force_fallback_adapter: false,
-    }))
-    .unwrap();
-
-    let (device, queue) = block_on(adapter.request_device(
-        &wgpu::DeviceDescriptor {
-            label: None,
-            required_features: wgpu::Features::empty(),
-            required_limits: wgpu::Limits::default(),
-        },
-        None,
-    ))
-    .unwrap();
-
-    // Set up swap chain
-    let surface_desc = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-        width: size.width,
-        height: size.height,
-        present_mode: wgpu::PresentMode::Fifo,
-        desired_maximum_frame_latency: 2,
-        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-        view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-    };
-
-    surface.configure(&device, &surface_desc);
-
-    // Set up dear imgui
-    let mut imgui = imgui::Context::create();
-    let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
-    platform.attach_window(
-        imgui.io_mut(),
-        &window,
-        imgui_winit_support::HiDpiMode::Default,
-    );
-    imgui.set_ini_filename(None);
-
-    let font_size = (13.0 * hidpi_factor) as f32;
-    imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
-
-    imgui.fonts().add_font(&[FontSource::DefaultFontData {
-        config: Some(imgui::FontConfig {
-            oversample_h: 1,
-            pixel_snap_h: true,
-            size_pixels: font_size,
-            ..Default::default()
-        }),
-    }]);
-
-    //
-    // Set up dear imgui wgpu renderer
-    //
-    let clear_color = wgpu::Color {
-        r: 0.1,
-        g: 0.2,
-        b: 0.3,
-        a: 1.0,
-    };
-    let renderer_config = RendererConfig {
-        texture_format: surface_desc.format,
-        ..Default::default()
-    };
-
-    let mut renderer = Renderer::new(&mut imgui, &device, &queue, renderer_config);
-
-    let mut last_frame = Instant::now();
-
-    // Set up checker texture
-    let checker_bytes = include_bytes!("../resources/checker.png");
-    let image = image::load_from_memory_with_format(checker_bytes, ImageFormat::Png)
-        .expect("invalid image");
-    let image = image.to_rgba8();
-    let (width, height) = image.dimensions();
-    let raw_data = image.into_raw();
-
-    let texture_config = TextureConfig {
-        size: Extent3d {
-            width,
-            height,
-            ..Default::default()
-        },
-        label: Some("checker texture"),
-        format: Some(wgpu::TextureFormat::Rgba8Unorm),
-        ..Default::default()
-    };
-
-    let texture = Texture::new(&device, &renderer, texture_config);
-
-    texture.write(&queue, &raw_data, width, height);
-    let checker_texture_id = renderer.textures.insert(texture);
-
-    let mut last_cursor = None;
-
-    // Event loop
-    let _ = event_loop.run(|event, elwt| {
-        if cfg!(feature = "metal-auto-capture") {
-            elwt.exit();
-        } else {
-            elwt.set_control_flow(ControlFlow::Poll)
-        };
-        match event {
-            Event::AboutToWait => window.request_redraw(),
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(size) => {
-                    let surface_desc = wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                        width: size.width,
-                        height: size.height,
-                        present_mode: wgpu::PresentMode::Fifo,
-                        desired_maximum_frame_latency: 2,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-                    };
-
-                    surface.configure(&device, &surface_desc);
-                }
-                WindowEvent::CloseRequested => elwt.exit(),
-                WindowEvent::KeyboardInput { event, .. } => {
-                    if let Key::Named(NamedKey::Escape) = event.logical_key {
-                        if event.state.is_pressed() {
-                            elwt.exit();
-                        }
-                    }
-                }
-                WindowEvent::RedrawRequested => {
-                    let now = Instant::now();
-                    imgui.io_mut().update_delta_time(now - last_frame);
-                    last_frame = now;
-
-                    let frame = match surface.get_current_texture() {
-                        Ok(frame) => frame,
-                        Err(e) => {
-                            eprintln!("dropped frame: {e:?}");
-                            return;
-                        }
-                    };
-                    platform
-                        .prepare_frame(imgui.io_mut(), &window)
-                        .expect("Failed to prepare frame");
-                    let ui = imgui.frame();
-
-                    {
-                        let size = [width as f32, height as f32];
-                        let window = ui.window("Hello world");
-                        window
-                            .size([400.0, 600.0], Condition::FirstUseEver)
-                            .build(|| {
-                                ui.text("Hello textures!");
-                                ui.text("Say hello to checker.png");
-                                Image::new(checker_texture_id, size).build(ui);
-                            });
-                    }
-
-                    let mut encoder: wgpu::CommandEncoder = device
-                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-                    if last_cursor != Some(ui.mouse_cursor()) {
-                        last_cursor = Some(ui.mouse_cursor());
-                        platform.prepare_render(ui, &window);
-                    }
-
-                    let view = frame
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default());
-                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: None,
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &view,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(clear_color),
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
-
-                    renderer
-                        .render(imgui.render(), &queue, &device, &mut rpass)
-                        .expect("Rendering failed");
-
-                    drop(rpass);
-
-                    queue.submit(Some(encoder.finish()));
-                    frame.present();
-                }
-                _ => {}
-            },
-            _ => {}
-        }
-
-        platform.handle_event(imgui.io_mut(), &window, &event);
-    });
+    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.run_app(&mut App::default()).unwrap();
 }

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -1,229 +1,341 @@
-extern crate imgui_winit_support;
-
 use imgui::*;
 use imgui_wgpu::{Renderer, RendererConfig};
+use imgui_winit_support::WinitPlatform;
 use pollster::block_on;
-
-use std::time::Instant;
+use std::{sync::Arc, time::Instant};
 use winit::{
+    application::ApplicationHandler,
     dpi::LogicalSize,
     event::{Event, WindowEvent},
-    event_loop::{ControlFlow, EventLoop},
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
     keyboard::{Key, NamedKey},
-    window::WindowBuilder,
+    window::Window,
 };
+
+struct ImguiState {
+    context: imgui::Context,
+    platform: WinitPlatform,
+    renderer: Renderer,
+    clear_color: wgpu::Color,
+    demo_open: bool,
+    last_frame: Instant,
+    last_cursor: Option<MouseCursor>,
+}
+
+struct AppWindow {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    window: Arc<Window>,
+    surface_desc: wgpu::SurfaceConfiguration,
+    surface: wgpu::Surface<'static>,
+    hidpi_factor: f64,
+    imgui: Option<ImguiState>,
+}
+
+#[derive(Default)]
+struct App {
+    window: Option<AppWindow>,
+}
+
+impl AppWindow {
+    fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            ..Default::default()
+        });
+
+        let window = {
+            let version = env!("CARGO_PKG_VERSION");
+
+            let size = LogicalSize::new(1280.0, 720.0);
+
+            let attributes = Window::default_attributes()
+                .with_inner_size(size)
+                .with_title(&format!("imgui-wgpu {version}"));
+            Arc::new(event_loop.create_window(attributes).unwrap())
+        };
+
+        let size = window.inner_size();
+        let hidpi_factor = window.scale_factor();
+        let surface = instance.create_surface(window.clone()).unwrap();
+
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .unwrap();
+
+        let (device, queue) =
+            block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None)).unwrap();
+
+        // Set up swap chain
+        let surface_desc = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            width: size.width,
+            height: size.height,
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        };
+
+        surface.configure(&device, &surface_desc);
+
+        let imgui = None;
+        Self {
+            device,
+            queue,
+            window,
+            surface_desc,
+            surface,
+            hidpi_factor,
+            imgui,
+        }
+    }
+
+    fn setup_imgui(&mut self) {
+        let mut context = imgui::Context::create();
+        let mut platform = imgui_winit_support::WinitPlatform::new(&mut context);
+        platform.attach_window(
+            context.io_mut(),
+            &self.window,
+            imgui_winit_support::HiDpiMode::Default,
+        );
+        context.set_ini_filename(None);
+
+        let font_size = (13.0 * self.hidpi_factor) as f32;
+        context.io_mut().font_global_scale = (1.0 / self.hidpi_factor) as f32;
+
+        context.fonts().add_font(&[FontSource::DefaultFontData {
+            config: Some(imgui::FontConfig {
+                oversample_h: 1,
+                pixel_snap_h: true,
+                size_pixels: font_size,
+                ..Default::default()
+            }),
+        }]);
+
+        //
+        // Set up dear imgui wgpu renderer
+        //
+        let clear_color = wgpu::Color {
+            r: 0.1,
+            g: 0.2,
+            b: 0.3,
+            a: 1.0,
+        };
+
+        let renderer_config = RendererConfig {
+            texture_format: self.surface_desc.format,
+            ..Default::default()
+        };
+
+        let renderer = Renderer::new(&mut context, &self.device, &self.queue, renderer_config);
+        let last_frame = Instant::now();
+        let last_cursor = None;
+        let demo_open = true;
+
+        self.imgui = Some(ImguiState {
+            context,
+            platform,
+            renderer,
+            clear_color,
+            demo_open,
+            last_frame,
+            last_cursor,
+        })
+    }
+
+    fn new(event_loop: &ActiveEventLoop) -> Self {
+        let mut window = Self::setup_gpu(event_loop);
+        window.setup_imgui();
+        window
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.window = Some(AppWindow::new(event_loop));
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+
+        match &event {
+            WindowEvent::Resized(size) => {
+                window.surface_desc = wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    width: size.width,
+                    height: size.height,
+                    present_mode: wgpu::PresentMode::Fifo,
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                };
+
+                window
+                    .surface
+                    .configure(&window.device, &window.surface_desc);
+            }
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::KeyboardInput { event, .. } => {
+                if let Key::Named(NamedKey::Escape) = event.logical_key {
+                    if event.state.is_pressed() {
+                        event_loop.exit();
+                    }
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let delta_s = imgui.last_frame.elapsed();
+                let now = Instant::now();
+                imgui
+                    .context
+                    .io_mut()
+                    .update_delta_time(now - imgui.last_frame);
+                imgui.last_frame = now;
+
+                let frame = match window.surface.get_current_texture() {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        eprintln!("dropped frame: {e:?}");
+                        return;
+                    }
+                };
+                imgui
+                    .platform
+                    .prepare_frame(imgui.context.io_mut(), &window.window)
+                    .expect("Failed to prepare frame");
+                let ui = imgui.context.frame();
+
+                {
+                    let window = ui.window("Hello world");
+                    window
+                        .size([300.0, 100.0], Condition::FirstUseEver)
+                        .build(|| {
+                            ui.text("Hello world!");
+                            ui.text("This...is...imgui-rs on WGPU!");
+                            ui.separator();
+                            let mouse_pos = ui.io().mouse_pos;
+                            ui.text(format!(
+                                "Mouse Position: ({:.1},{:.1})",
+                                mouse_pos[0], mouse_pos[1]
+                            ));
+                        });
+
+                    let window = ui.window("Hello too");
+                    window
+                        .size([400.0, 200.0], Condition::FirstUseEver)
+                        .position([400.0, 200.0], Condition::FirstUseEver)
+                        .build(|| {
+                            ui.text(format!("Frametime: {delta_s:?}"));
+                        });
+
+                    ui.show_demo_window(&mut imgui.demo_open);
+                }
+
+                let mut encoder: wgpu::CommandEncoder = window
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                if imgui.last_cursor != ui.mouse_cursor() {
+                    imgui.last_cursor = ui.mouse_cursor();
+                    imgui.platform.prepare_render(ui, &window.window);
+                }
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(imgui.clear_color),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                imgui
+                    .renderer
+                    .render(
+                        imgui.context.render(),
+                        &window.queue,
+                        &window.device,
+                        &mut rpass,
+                    )
+                    .expect("Rendering failed");
+
+                drop(rpass);
+
+                window.queue.submit(Some(encoder.finish()));
+
+                frame.present();
+            }
+            _ => (),
+        }
+
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::WindowEvent { window_id, event },
+        );
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: ()) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::UserEvent(event),
+        );
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::DeviceEvent { device_id, event },
+        );
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        window.window.request_redraw();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::AboutToWait,
+        );
+    }
+}
 
 fn main() {
     env_logger::init();
 
-    // Set up window and GPU
     let event_loop = EventLoop::new().unwrap();
-
-    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::PRIMARY,
-        ..Default::default()
-    });
-
-    let window = {
-        let version = env!("CARGO_PKG_VERSION");
-
-        let size = LogicalSize::new(1280.0, 720.0);
-        WindowBuilder::new()
-            .with_inner_size(size)
-            .with_title(&format!("imgui-wgpu {version}"))
-            .build(&event_loop)
-            .unwrap()
-    };
-    let size = window.inner_size();
-    let surface = instance.create_surface(&window).unwrap();
-
-    let hidpi_factor = window.scale_factor();
-
-    let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
-        power_preference: wgpu::PowerPreference::HighPerformance,
-        compatible_surface: Some(&surface),
-        force_fallback_adapter: false,
-    }))
-    .unwrap();
-
-    let (device, queue) =
-        block_on(adapter.request_device(&wgpu::DeviceDescriptor::default(), None)).unwrap();
-
-    // Set up swap chain
-    let surface_desc = wgpu::SurfaceConfiguration {
-        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-        width: size.width,
-        height: size.height,
-        present_mode: wgpu::PresentMode::Fifo,
-        desired_maximum_frame_latency: 2,
-        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-        view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-    };
-
-    surface.configure(&device, &surface_desc);
-
-    // Set up dear imgui
-    let mut imgui = imgui::Context::create();
-    let mut platform = imgui_winit_support::WinitPlatform::init(&mut imgui);
-    platform.attach_window(
-        imgui.io_mut(),
-        &window,
-        imgui_winit_support::HiDpiMode::Default,
-    );
-    imgui.set_ini_filename(None);
-
-    let font_size = (13.0 * hidpi_factor) as f32;
-    imgui.io_mut().font_global_scale = (1.0 / hidpi_factor) as f32;
-
-    imgui.fonts().add_font(&[FontSource::DefaultFontData {
-        config: Some(imgui::FontConfig {
-            oversample_h: 1,
-            pixel_snap_h: true,
-            size_pixels: font_size,
-            ..Default::default()
-        }),
-    }]);
-
-    //
-    // Set up dear imgui wgpu renderer
-    //
-    let clear_color = wgpu::Color {
-        r: 0.1,
-        g: 0.2,
-        b: 0.3,
-        a: 1.0,
-    };
-
-    let renderer_config = RendererConfig {
-        texture_format: surface_desc.format,
-        ..Default::default()
-    };
-
-    let mut renderer = Renderer::new(&mut imgui, &device, &queue, renderer_config);
-
-    let mut last_frame = Instant::now();
-    let mut demo_open = true;
-
-    let mut last_cursor = None;
-
-    // Event loop
-    let _ = event_loop.run(|event, elwt| {
-        if cfg!(feature = "metal-auto-capture") {
-            elwt.exit();
-        } else {
-            elwt.set_control_flow(ControlFlow::Poll);
-        };
-        match event {
-            Event::AboutToWait => window.request_redraw(),
-            Event::WindowEvent { ref event, .. } => match event {
-                WindowEvent::Resized(size) => {
-                    let surface_desc = wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: wgpu::TextureFormat::Bgra8UnormSrgb,
-                        width: size.width,
-                        height: size.height,
-                        present_mode: wgpu::PresentMode::Fifo,
-                        desired_maximum_frame_latency: 2,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
-                    };
-
-                    surface.configure(&device, &surface_desc);
-                }
-                WindowEvent::CloseRequested => elwt.exit(),
-                WindowEvent::KeyboardInput { event, .. } => {
-                    if let Key::Named(NamedKey::Escape) = event.logical_key {
-                        if event.state.is_pressed() {
-                            elwt.exit();
-                        }
-                    }
-                }
-                WindowEvent::RedrawRequested => {
-                    let delta_s = last_frame.elapsed();
-                    let now = Instant::now();
-                    imgui.io_mut().update_delta_time(now - last_frame);
-                    last_frame = now;
-
-                    let frame = match surface.get_current_texture() {
-                        Ok(frame) => frame,
-                        Err(e) => {
-                            eprintln!("dropped frame: {e:?}");
-                            return;
-                        }
-                    };
-                    platform
-                        .prepare_frame(imgui.io_mut(), &window)
-                        .expect("Failed to prepare frame");
-                    let ui = imgui.frame();
-
-                    {
-                        let window = ui.window("Hello world");
-                        window
-                            .size([300.0, 100.0], Condition::FirstUseEver)
-                            .build(|| {
-                                ui.text("Hello world!");
-                                ui.text("This...is...imgui-rs on WGPU!");
-                                ui.separator();
-                                let mouse_pos = ui.io().mouse_pos;
-                                ui.text(format!(
-                                    "Mouse Position: ({:.1},{:.1})",
-                                    mouse_pos[0], mouse_pos[1]
-                                ));
-                            });
-
-                        let window = ui.window("Hello too");
-                        window
-                            .size([400.0, 200.0], Condition::FirstUseEver)
-                            .position([400.0, 200.0], Condition::FirstUseEver)
-                            .build(|| {
-                                ui.text(format!("Frametime: {delta_s:?}"));
-                            });
-
-                        ui.show_demo_window(&mut demo_open);
-                    }
-
-                    let mut encoder: wgpu::CommandEncoder = device
-                        .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-
-                    if last_cursor != Some(ui.mouse_cursor()) {
-                        last_cursor = Some(ui.mouse_cursor());
-                        platform.prepare_render(ui, &window);
-                    }
-
-                    let view = frame
-                        .texture
-                        .create_view(&wgpu::TextureViewDescriptor::default());
-                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: None,
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &view,
-                            resolve_target: None,
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(clear_color),
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
-
-                    renderer
-                        .render(imgui.render(), &queue, &device, &mut rpass)
-                        .expect("Rendering failed");
-
-                    drop(rpass);
-
-                    queue.submit(Some(encoder.finish()));
-
-                    frame.present();
-                }
-                _ => {}
-            },
-            _ => {}
-        }
-
-        platform.handle_event(imgui.io_mut(), &window, &event);
-    });
+    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.run_app(&mut App::default()).unwrap();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -443,6 +443,7 @@ impl Renderer {
             vertex: VertexState {
                 module: &shader_module,
                 entry_point: vertex_shader_entry_point.unwrap(),
+                compilation_options: Default::default(),
                 buffers: &[VertexBufferLayout {
                     array_stride: size_of::<DrawVert>() as BufferAddress,
                     step_mode: VertexStepMode::Vertex,
@@ -472,6 +473,7 @@ impl Renderer {
             fragment: Some(FragmentState {
                 module: &shader_module,
                 entry_point: fragment_shader_entry_point.unwrap(),
+                compilation_options: Default::default(),
                 targets: &[Some(ColorTargetState {
                     format: texture_format,
                     blend: Some(BlendState {
@@ -490,6 +492,7 @@ impl Renderer {
                 })],
             }),
             multiview: None,
+            cache: None,
         });
 
         let mut renderer = Self {


### PR DESCRIPTION

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [ ] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Bumped wgpu to version 22.1. Consists of three commits:
- bumping the dependency version, updating src/lib.rs slightly to the newer version
- Fixing the examples with the new version of wgpu/winit
- Adding skip rules to deny.toml

## Related Issues
