### PR TITLE
Update wgpu version to 24.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ bytemuck = "1"
 imgui = "0.12"
 log = "0.4"
 smallvec = "1"
-wgpu = "23.0"
+wgpu = "24.0.1"
 
 [dev-dependencies]
 bytemuck = { version = "1.13", features = ["derive"] }

--- a/examples/cube.rs
+++ b/examples/cube.rs
@@ -362,7 +362,7 @@ struct App {
 
 impl AppWindow {
     fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::PRIMARY,
             ..Default::default()
         });

--- a/examples/custom-texture.rs
+++ b/examples/custom-texture.rs
@@ -43,7 +43,7 @@ struct App {
 
 impl AppWindow {
     fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::PRIMARY,
             ..Default::default()
         });

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -39,7 +39,7 @@ struct App {
 
 impl AppWindow {
     fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
             backends: wgpu::Backends::PRIMARY,
             ..Default::default()
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ pub struct TextureConfig<'a> {
     pub sampler_desc: SamplerDescriptor<'a>,
 }
 
-impl<'a> Default for TextureConfig<'a> {
+impl Default for TextureConfig<'_> {
     /// Create a new texture config.
     fn default() -> Self {
         let sampler_desc = SamplerDescriptor {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl Texture {
     pub fn write(&self, queue: &Queue, data: &[u8], width: u32, height: u32) {
         queue.write_texture(
             // destination (sub)texture
-            ImageCopyTexture {
+            TexelCopyTextureInfo {
                 texture: &self.texture,
                 mip_level: 0,
                 origin: Origin3d { x: 0, y: 0, z: 0 },
@@ -228,7 +228,7 @@ impl Texture {
             // source bitmap data
             data,
             // layout of the source bitmap
-            ImageDataLayout {
+            TexelCopyBufferLayout {
                 offset: 0,
                 bytes_per_row: Some(width * 4),
                 rows_per_image: Some(height),


### PR DESCRIPTION
## Description
Updated version from 23.0 to 24.0.1.
I wanted to add imgui into my app but the version of wgpu required for this package broke my app. (myapp uses 24.0.1, the latest version)
I've updated the version of wgpu in the dependency to 24.0.1 and the examples to check that it doesn't cause any issues. ;-)

## Related Issues
