### PR TITLE
fix: respect ImDrawCmd idx_offset in render_draw_list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Bump wgpu version to 22.1. @aftix
 - Bump wgpu version to 23.0. @SupernaviX
 - Internal: Update cargo-deny config to handle breaking changes. @SupernaviX
+- Internal: Respect `ImDrawCmd` `idx_offset` in` render_draw_list` to correctly render modal overlays. @CrushedPixel
 
 ## v0.24.0
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -704,8 +704,6 @@ impl Renderer {
         clip_scale: [f32; 2],
         (vertex_base, index_base): (i32, u32),
     ) -> RendererResult<()> {
-        let mut start = index_base;
-
         for cmd in draw_list.commands() {
             if let Elements { count, cmd_params } = cmd {
                 let clip_rect = [
@@ -724,6 +722,7 @@ impl Renderer {
                 rpass.set_bind_group(1, Some(tex.bind_group.as_ref()), &[]);
 
                 // Set scissors on the renderpass.
+                let start = index_base + cmd_params.idx_offset as u32;
                 let end = start + count as u32;
                 if clip_rect[0] < fb_size[0]
                     && clip_rect[1] < fb_size[1]
@@ -750,13 +749,13 @@ impl Renderer {
                         rpass.set_scissor_rect(scissors.0, scissors.1, scissors.2, scissors.3);
 
                         // Draw the current batch of vertices with the renderpass.
-                        rpass.draw_indexed(start..end, vertex_base, 0..1);
+                        rpass.draw_indexed(
+                            start..end,
+                            vertex_base + cmd_params.vtx_offset as i32,
+                            0..1,
+                        );
                     }
                 }
-
-                // Increment the index regardless of whether or not this batch
-                // of vertices was drawn.
-                start = end;
             }
         }
         Ok(())


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description
Previously, `render_draw_list` assumed all draw commands were contiguous in the index buffer and manually tracked a running index offset. This worked for older ImGui versions but breaks in version 1.86+, which relies on explicit `idx_offset` and `vtx_offset` values for correct layering, for example for modals and overlays.

@ocornut explains here why this breaks in 1.86+:
https://github.com/ocornut/imgui/issues/4863#issuecomment-1005225877

This PR updates `render_draw_list` to use the provided offsets from `ImDrawCmdParams`, ensuring draw calls reference the correct index range regardless of command order.

This fixes a bug where fullscreen overlays (e.g. the [ImGuiFileDialog](https://github.com/aiekick/ImGuiFileDialog/) modal overlay) were drawn in front of modal windows due to incorrect command ordering.

Old:
<img width="1392" alt="Screenshot 2025-06-26 at 22 55 40" src="https://github.com/user-attachments/assets/d0cfbaeb-2f1e-42fa-b50f-22026854309e" />
New:
<img width="1392" alt="Screenshot 2025-06-26 at 22 50 52" src="https://github.com/user-attachments/assets/e9e2e326-00e4-4a7d-951c-32e2ffc0512e" />

