### PR TITLE
Fix Issue #114 - crash on empty draw list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Per Keep a Changelog there are 6 main categories of changes:
 - Bump wgpu version to 22.1. @aftix
 - Bump wgpu version to 23.0. @SupernaviX
 - Internal: Update cargo-deny config to handle breaking changes. @SupernaviX
+- Internal: Fix crash when draw list is empty. @jbrd
 
 ## v0.24.0
 

--- a/examples/empty.rs
+++ b/examples/empty.rs
@@ -1,0 +1,314 @@
+use imgui::*;
+use imgui_wgpu::{Renderer, RendererConfig};
+use imgui_winit_support::WinitPlatform;
+use pollster::block_on;
+use std::{sync::Arc, time::Instant};
+use winit::{
+    application::ApplicationHandler,
+    dpi::LogicalSize,
+    event::{Event, WindowEvent},
+    event_loop::{ActiveEventLoop, ControlFlow, EventLoop},
+    keyboard::{Key, NamedKey},
+    window::Window,
+};
+
+struct ImguiState {
+    context: imgui::Context,
+    platform: WinitPlatform,
+    renderer: Renderer,
+    clear_color: wgpu::Color,
+    last_frame: Instant,
+    last_cursor: Option<MouseCursor>,
+}
+
+struct AppWindow {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    window: Arc<Window>,
+    surface_desc: wgpu::SurfaceConfiguration,
+    surface: wgpu::Surface<'static>,
+    hidpi_factor: f64,
+    imgui: Option<ImguiState>,
+}
+
+#[derive(Default)]
+struct App {
+    window: Option<AppWindow>,
+}
+
+impl AppWindow {
+    fn setup_gpu(event_loop: &ActiveEventLoop) -> Self {
+        let instance = wgpu::Instance::new(&wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::PRIMARY,
+            ..Default::default()
+        });
+
+        let window = {
+            let version = env!("CARGO_PKG_VERSION");
+
+            let size = LogicalSize::new(1280.0, 720.0);
+
+            let attributes = Window::default_attributes()
+                .with_inner_size(size)
+                .with_title(format!("imgui-wgpu {version}"));
+            Arc::new(event_loop.create_window(attributes).unwrap())
+        };
+
+        let size = window.inner_size();
+        let hidpi_factor = window.scale_factor();
+        let surface = instance.create_surface(window.clone()).unwrap();
+
+        let adapter = block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: Some(&surface),
+            force_fallback_adapter: false,
+        }))
+        .unwrap();
+
+        let (device, queue) =
+            block_on(adapter.request_device(&wgpu::DeviceDescriptor::default())).unwrap();
+
+        // Set up swap chain
+        let surface_desc = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format: wgpu::TextureFormat::Bgra8UnormSrgb,
+            width: size.width,
+            height: size.height,
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 2,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+        };
+
+        surface.configure(&device, &surface_desc);
+
+        let imgui = None;
+        Self {
+            device,
+            queue,
+            window,
+            surface_desc,
+            surface,
+            hidpi_factor,
+            imgui,
+        }
+    }
+
+    fn setup_imgui(&mut self) {
+        let mut context = imgui::Context::create();
+        let mut platform = imgui_winit_support::WinitPlatform::new(&mut context);
+        platform.attach_window(
+            context.io_mut(),
+            &self.window,
+            imgui_winit_support::HiDpiMode::Default,
+        );
+        context.set_ini_filename(None);
+
+        let font_size = (13.0 * self.hidpi_factor) as f32;
+        context.io_mut().font_global_scale = (1.0 / self.hidpi_factor) as f32;
+
+        context.fonts().add_font(&[FontSource::DefaultFontData {
+            config: Some(imgui::FontConfig {
+                oversample_h: 1,
+                pixel_snap_h: true,
+                size_pixels: font_size,
+                ..Default::default()
+            }),
+        }]);
+
+        //
+        // Set up dear imgui wgpu renderer
+        //
+        let clear_color = wgpu::Color {
+            r: 0.1,
+            g: 0.2,
+            b: 0.3,
+            a: 1.0,
+        };
+
+        let renderer_config = RendererConfig {
+            texture_format: self.surface_desc.format,
+            ..Default::default()
+        };
+
+        let renderer = Renderer::new(&mut context, &self.device, &self.queue, renderer_config);
+        let last_frame = Instant::now();
+        let last_cursor = None;
+
+        self.imgui = Some(ImguiState {
+            context,
+            platform,
+            renderer,
+            clear_color,
+            last_frame,
+            last_cursor,
+        })
+    }
+
+    fn new(event_loop: &ActiveEventLoop) -> Self {
+        let mut window = Self::setup_gpu(event_loop);
+        window.setup_imgui();
+        window
+    }
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.window = Some(AppWindow::new(event_loop));
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        window_id: winit::window::WindowId,
+        event: WindowEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+
+        match &event {
+            WindowEvent::Resized(size) => {
+                window.surface_desc = wgpu::SurfaceConfiguration {
+                    usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                    format: wgpu::TextureFormat::Bgra8UnormSrgb,
+                    width: size.width,
+                    height: size.height,
+                    present_mode: wgpu::PresentMode::Fifo,
+                    desired_maximum_frame_latency: 2,
+                    alpha_mode: wgpu::CompositeAlphaMode::Auto,
+                    view_formats: vec![wgpu::TextureFormat::Bgra8Unorm],
+                };
+
+                window
+                    .surface
+                    .configure(&window.device, &window.surface_desc);
+            }
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::KeyboardInput { event, .. } => {
+                if let Key::Named(NamedKey::Escape) = event.logical_key {
+                    if event.state.is_pressed() {
+                        event_loop.exit();
+                    }
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                let now = Instant::now();
+                imgui
+                    .context
+                    .io_mut()
+                    .update_delta_time(now - imgui.last_frame);
+                imgui.last_frame = now;
+
+                let frame = match window.surface.get_current_texture() {
+                    Ok(frame) => frame,
+                    Err(e) => {
+                        eprintln!("dropped frame: {e:?}");
+                        return;
+                    }
+                };
+                imgui
+                    .platform
+                    .prepare_frame(imgui.context.io_mut(), &window.window)
+                    .expect("Failed to prepare frame");
+                let ui = imgui.context.frame();
+
+                // Deliberately do not submit anything such that the draw buffer is empty.
+                // The renderer should cope gracefully with this.
+
+                let mut encoder: wgpu::CommandEncoder = window
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                if imgui.last_cursor != ui.mouse_cursor() {
+                    imgui.last_cursor = ui.mouse_cursor();
+                    imgui.platform.prepare_render(ui, &window.window);
+                }
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                    label: None,
+                    color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                        view: &view,
+                        resolve_target: None,
+                        ops: wgpu::Operations {
+                            load: wgpu::LoadOp::Clear(imgui.clear_color),
+                            store: wgpu::StoreOp::Store,
+                        },
+                    })],
+                    depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                });
+
+                imgui
+                    .renderer
+                    .render(
+                        imgui.context.render(),
+                        &window.queue,
+                        &window.device,
+                        &mut rpass,
+                    )
+                    .expect("Rendering failed");
+
+                drop(rpass);
+
+                window.queue.submit(Some(encoder.finish()));
+
+                frame.present();
+            }
+            _ => (),
+        }
+
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::WindowEvent { window_id, event },
+        );
+    }
+
+    fn user_event(&mut self, _event_loop: &ActiveEventLoop, event: ()) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::UserEvent(event),
+        );
+    }
+
+    fn device_event(
+        &mut self,
+        _event_loop: &ActiveEventLoop,
+        device_id: winit::event::DeviceId,
+        event: winit::event::DeviceEvent,
+    ) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::DeviceEvent { device_id, event },
+        );
+    }
+
+    fn about_to_wait(&mut self, _event_loop: &ActiveEventLoop) {
+        let window = self.window.as_mut().unwrap();
+        let imgui = window.imgui.as_mut().unwrap();
+        window.window.request_redraw();
+        imgui.platform.handle_event::<()>(
+            imgui.context.io_mut(),
+            &window.window,
+            &Event::AboutToWait,
+        );
+    }
+}
+
+fn main() {
+    env_logger::init();
+
+    let event_loop = EventLoop::new().unwrap();
+    event_loop.set_control_flow(ControlFlow::Poll);
+    event_loop.run_app(&mut App::default()).unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,6 +551,12 @@ impl Renderer {
             render_data.render = true;
         }
 
+        // If there are no draw lists, exit here
+        if draw_data.draw_lists_count() == 0 {
+            render_data.render = false;
+            return render_data;
+        }
+
         // Only update matrices if the size or position changes
         if (render_data.last_size[0] - draw_data.display_size[0]).abs() > f32::EPSILON
             || (render_data.last_size[1] - draw_data.display_size[1]).abs() > f32::EPSILON
@@ -655,13 +661,20 @@ impl Renderer {
             return Ok(());
         }
 
+        let vertex_buffer = render_data.vertex_buffer.as_ref().unwrap();
+        if vertex_buffer.size() == 0 {
+            return Ok(());
+        }
+
+        let index_buffer = render_data.index_buffer.as_ref().unwrap();
+        if index_buffer.size() == 0 {
+            return Ok(());
+        }
+
         rpass.set_pipeline(&self.pipeline);
         rpass.set_bind_group(0, &self.uniform_bind_group, &[]);
-        rpass.set_vertex_buffer(0, render_data.vertex_buffer.as_ref().unwrap().slice(..));
-        rpass.set_index_buffer(
-            render_data.index_buffer.as_ref().unwrap().slice(..),
-            IndexFormat::Uint16,
-        );
+        rpass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        rpass.set_index_buffer(index_buffer.slice(..), IndexFormat::Uint16);
 
         // Execute all the imgui render work.
         for (draw_list, bases) in draw_data


### PR DESCRIPTION
<!-- Thank you for making a pull request! Below are the recommended steps to validate that your PR will pass CI -->

## Checklist

- [x] `cargo clippy` reports no issues
- [x] `cargo doc` reports no issues
- [x] [`cargo deny`](https://github.com/EmbarkStudios/cargo-deny/) issues have been fixed or added to `deny.toml`
- [x] human-readable change descriptions added to the changelog under the "Unreleased" heading.
  - [x] If the change does not affect the user (or is a process change), preface the change with "Internal:"
  - [x] Add credit to yourself for each change: `Added new functionality @githubname`.

## Description

Fix a crash that occurs when submitting an empty draw list, and harden against invalid slice access. Added an example that can be used as a regression test.

Contributing upstream from https://github.com/jbrd/bevy_mod_imgui/pull/57
(originally uncovered in https://github.com/jbrd/bevy_mod_imgui/pull/55).

## Related Issues

Issue #114 